### PR TITLE
Refresh Above The Stack site with light theme and English content

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/README.md
+++ b/README.md
@@ -1,43 +1,42 @@
 # Above The Stack — Website (Next.js / Tailwind)
 
-Vendor‑neutrale inzichten, playbooks en community voor MSP’s.  
-MVP met App Router, Tailwind, en Discourse integratie (laatste topics).
+Vendor-neutral insights, playbooks, and community for MSPs.
+MVP built with the App Router, Tailwind CSS, and a Discourse integration for the latest topics.
 
-## Snel starten
+## Quick start
 
 ```bash
-pnpm i # of npm i / yarn
-pnpm dev # of npm run dev
+pnpm i # or npm i / yarn
+pnpm dev # or npm run dev
 ```
 
-Open http://localhost:3000
+Open http://localhost:3000.
 
-## Omgevingsvariabelen
+## Environment variables
 
-Maak `.env.local` met:
+Create `.env.local` with:
 
 ```
 NEXT_PUBLIC_PORTAL_URL=https://portal.abovethestack.com
 DISCOURSE_URL=https://portal.abovethestack.com
-DISC_API_KEY= # optioneel (leesrechten)
+DISC_API_KEY= # optional (read access)
 DISC_API_USERNAME=system
 ```
 
-> Zonder API key valt de widget terug op dummy data.
+> Without an API key the widget falls back to dummy data.
 
 ## Deploy
 
-- Push naar GitHub en importeer in Vercel.
-- Zet `.env` variabelen in Vercel Project Settings.
-- (Optioneel) Vercel Analytics/PostHog toevoegen.
+- Push to GitHub and import the repo in Vercel.
+- Configure the `.env` variables in your Vercel Project Settings.
+- (Optional) Add Vercel Analytics or PostHog.
 
-## Verder bouwen
+## Next steps
 
-- Content als MDX + Contentlayer (later toevoegen).
-- SSO met Discourse (DiscourseConnect) via `/api/auth/discourse` (stub nog toevoegen).
-- Events pagina koppelen aan een CMS of MDX.
-- Nieuwsbrief: vervang `YOUR_WEB3FORMS_KEY` of koppel aan je provider.
-```
+- Move content to MDX + Contentlayer (to be added later).
+- Implement DiscourseConnect SSO via `/api/auth/discourse` (stub still pending).
+- Power the Events page with a CMS or MDX.
+- Newsletter: replace `YOUR_WEB3FORMS_KEY` or connect to your provider.
 
-## Licentie
+## License
 MIT

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,31 +2,28 @@ export const metadata = { title: "About — Above The Stack" };
 
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>About Above The Stack</h1>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">About Above The Stack</h1>
       <p>
-        Above The Stack is the independent platform where Managed Service
-        Providers, vendors, and IT leaders access research, playbooks, and a
-        peer community — free from vendor bias and focused on real outcomes.
+        Above The Stack is the independent platform where Managed Service Providers, vendors, and
+        IT leaders access research, playbooks, and a peer community — free from vendor bias and
+        focused on real outcomes.
       </p>
       <p>
-        We are launching in Europe with a strong emphasis on digital
-        sovereignty, compliance, and trust. Our mission is to provide MSPs with
-        the knowledge and tools they need to grow in a rapidly changing
-        regulatory and technological landscape.
+        We are launching in Europe with a strong emphasis on digital sovereignty, compliance, and
+        trust. Our mission is to equip MSPs with the knowledge and tools they need to grow in a
+        rapidly changing regulatory and technological landscape.
       </p>
       <p>
-        While our roots are European, our vision is global. We believe that the
-        lessons learned here — around sovereignty, security, and sustainable
-        growth — can benefit MSPs and technology partners everywhere. As our
-        community grows, we welcome perspectives from the United States, Asia,
-        and beyond.
+        While our roots are European, our vision is global. The lessons learned here — around
+        sovereignty, security, and sustainable growth — can benefit MSPs and technology partners
+        everywhere. As our community expands, we welcome perspectives from North America, Asia, and
+        beyond.
       </p>
       <p>
-        Above The Stack is more than a resource hub — it’s a community. Whether
-        you are an MSP seeking clarity, a vendor wanting to better serve your
-        partners, or a student exploring the IT channel, you’ll find a place
-        here to learn, share, and grow.
+        Above The Stack is more than a resource hub — it is a community. Whether you are an MSP
+        seeking clarity, a vendor wanting to better serve your partners, or a student exploring the
+        IT channel, you will find a place here to learn, share, and grow.
       </p>
     </div>
   );

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -1,12 +1,25 @@
 export const metadata = { title: "Community — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Community</h1>
-      <p>Ons forum draait op Discourse. Je kunt meelezen en deelnemen via het portaal.</p>
-      <p><a className="btn-primary" href={process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}>Ga naar het forum</a></p>
-      <h2>Laatste topics</h2>
-      <iframe className="w-full h-[600px] rounded-2xl border border-neutral-800" src={(process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com') + '/latest'} />
+    <div className="space-y-8 text-slate-700">
+      <div className="space-y-4">
+        <h1 className="h1 text-atsMidnight">Community</h1>
+        <p>
+          Our forum runs on Discourse so you can read, share, and collaborate with peers. Use the
+          community portal to join the discussion and access member-only spaces.
+        </p>
+        <a className="btn-primary inline-flex" href={process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}>
+          Enter the community portal
+        </a>
+      </div>
+      <div className="space-y-4">
+        <h2 className="h2 text-atsMidnight">Latest topics</h2>
+        <iframe
+          className="h-[600px] w-full rounded-3xl border border-slate-200 bg-white shadow-[0_18px_40px_-20px_rgba(15,31,75,0.2)]"
+          src={(process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com') + '/latest'}
+          title="Above The Stack community"
+        />
+      </div>
     </div>
   )
 }

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,9 +1,12 @@
 export const metadata = { title: "Events & Roundtables — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Events & Roundtables</h1>
-      <p>Agenda, inschrijvingen en verslagen. Binnenkort meer.</p>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">Events &amp; Roundtables</h1>
+      <p>
+        Live sessions where operators and technology partners exchange playbooks, pricing tactics,
+        and lessons learned. Our full agenda and registration links will be published soon.
+      </p>
     </div>
   )
 }

--- a/app/events/pricing-2025/page.tsx
+++ b/app/events/pricing-2025/page.tsx
@@ -1,9 +1,26 @@
-export const metadata = { title: "Roundtable: Pricing in 2025 — Above The Stack" };
+export const metadata = { title: "Roundtable: MSP Pricing Strategies 2025 — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Roundtable: Pricing in 2025</h1>
-      <p>Binnenkort meer details en inschrijving.</p>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">Roundtable: MSP Pricing Strategies 2025</h1>
+      <p>
+        We are finalising the agenda for an operator-only conversation on packaging, value metrics,
+        and outcome-based pricing. Registration opens soon.
+      </p>
+      <p>
+        Join the newsletter or community to be the first to know when seats become available.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <a className="btn-primary" href="/newsletter">
+          Get event alerts
+        </a>
+        <a
+          className="btn-ghost"
+          href={process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}
+        >
+          Discuss with peers
+        </a>
+      </div>
     </div>
   )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,32 +3,45 @@
 @tailwind utilities;
 
 :root {
-  color-scheme: dark;
+  color-scheme: light;
 }
 
-html, body {
-  @apply bg-neutral-950 text-neutral-100;
-  background-image: theme('backgroundImage.grid');
-  background-size: 20px 20px;
+html,
+body {
+  @apply min-h-screen bg-white text-slate-900 antialiased;
+  background-color: #f7faff;
+  background-image:
+    radial-gradient(circle at 0 0, rgba(51, 199, 255, 0.18), transparent 55%),
+    radial-gradient(circle at 100% 0, rgba(38, 65, 214, 0.15), transparent 45%),
+    radial-gradient(circle at 50% 120%, rgba(255, 122, 89, 0.22), transparent 55%),
+    theme('backgroundImage.grid');
+  background-size: cover, cover, cover, 20px 20px;
+  background-repeat: no-repeat, no-repeat, no-repeat, repeat;
 }
 
 .container {
-  @apply mx-auto px-4 max-w-6xl;
+  @apply mx-auto max-w-6xl px-4;
 }
 
 .btn {
-  @apply inline-flex items-center gap-2 rounded-2xl px-4 py-2 font-medium transition;
+  @apply inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-atsOcean;
 }
 .btn-primary {
-  @apply btn bg-gradient-to-r from-atsRed to-atsViolet text-white hover:opacity-90;
+  @apply btn bg-gradient-to-r from-atsSky via-atsOcean to-atsCoral text-white shadow-glow hover:opacity-95;
 }
 .btn-ghost {
-  @apply btn bg-neutral-900 hover:bg-neutral-800 border border-neutral-800;
+  @apply btn border border-slate-200 bg-white text-atsOcean hover:bg-slate-50;
 }
 
 .card {
-  @apply rounded-2xl bg-neutral-900/70 border border-neutral-800 p-5 shadow;
+  @apply rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-[0_18px_40px_-20px_rgba(15,31,75,0.3)];
 }
-.h1 { @apply text-4xl md:text-5xl font-bold tracking-tight; }
-.h2 { @apply text-2xl md:text-3xl font-semibold; }
-.muted { @apply text-neutral-400; }
+.h1 {
+  @apply text-4xl md:text-5xl font-bold tracking-tight;
+}
+.h2 {
+  @apply text-2xl md:text-3xl font-semibold;
+}
+.muted {
+  @apply text-slate-600;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,38 +16,65 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="nl">
+    <html lang="en">
       <body>
-        <header className="sticky top-0 z-50 border-b border-neutral-800 backdrop-blur bg-neutral-950/60">
-          <div className="container flex items-center justify-between h-14">
-            <Link href="/" className="font-semibold">Above The Stack</Link>
-            <nav className="flex gap-6 text-sm">
-              <Link href="/research">Research</Link>
-              <Link href="/playbooks">Playbooks</Link>
-              <Link href="/events">Events</Link>
-              <Link href="/community">Community</Link>
-              <Link href="/about">Over</Link>
-              <Link href="/newsletter" className="btn-primary">Nieuwsbrief</Link>
+        <header className="sticky top-0 z-50 border-b border-slate-200/80 bg-white/80 backdrop-blur">
+          <div className="container flex h-16 items-center justify-between">
+            <Link
+              href="/"
+              className="text-lg font-semibold text-atsMidnight transition hover:text-atsOcean"
+            >
+              Above The Stack
+            </Link>
+            <nav className="flex flex-wrap items-center gap-4 text-sm font-medium text-slate-700">
+              <Link className="transition hover:text-atsOcean" href="/research">
+                Research
+              </Link>
+              <Link className="transition hover:text-atsOcean" href="/playbooks">
+                Playbooks
+              </Link>
+              <Link className="transition hover:text-atsOcean" href="/events">
+                Events
+              </Link>
+              <Link className="transition hover:text-atsOcean" href="/community">
+                Community
+              </Link>
+              <Link className="transition hover:text-atsOcean" href="/about">
+                About
+              </Link>
+              <Link className="btn-primary text-sm shadow-none" href="/newsletter">
+                Newsletter
+              </Link>
             </nav>
           </div>
         </header>
-        <main className="container py-10">{children}</main>
-        <footer className="border-t border-neutral-800 mt-10">
-  <div className="container py-10 text-sm text-neutral-400">
-    <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-      <p>
-        © {new Date().getFullYear()} Above The Stack. Launching in Europe. Built for the world.
-      </p>
-      <div className="flex gap-4">
-        <a href="/privacy">Privacy</a>
-        <a href="/contact">Contact</a>
-        <a href={process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}>
-          Community
-        </a>
-      </div>
-    </div>
-  </div>
-</footer>
+        <main className="container py-16">{children}</main>
+        <footer className="mt-16 border-t border-slate-200/80 bg-white/80">
+          <div className="container py-10 text-sm text-slate-600">
+            <div className="flex flex-col items-start justify-between gap-4 md:flex-row md:items-center">
+              <p>
+                © {new Date().getFullYear()} Above The Stack. Launching in Europe. Built for the
+                world.
+              </p>
+              <div className="flex gap-4">
+                <a className="transition hover:text-atsOcean" href="/privacy">
+                  Privacy
+                </a>
+                <a className="transition hover:text-atsOcean" href="/contact">
+                  Contact
+                </a>
+                <a
+                  className="transition hover:text-atsOcean"
+                  href={
+                    process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
+                  }
+                >
+                  Community
+                </a>
+              </div>
+            </div>
+          </div>
+        </footer>
       </body>
     </html>
   )

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -1,14 +1,22 @@
-export const metadata = { title: "Nieuwsbrief — Above The Stack" };
+export const metadata = { title: "Newsletter — Above The Stack" };
 export default function Page() {
   return (
-    <div className="max-w-xl">
-      <h1 className="h1">Nieuwsbrief</h1>
-      <p className="muted mt-3">Maandelijks. Kort. Praktisch. Geen spam.</p>
-      <form className="mt-6 card" action="https://api.web3forms.com/submit" method="POST">
+    <div className="mx-auto max-w-xl">
+      <h1 className="h1 text-atsMidnight">Newsletter</h1>
+      <p className="muted mt-3">Monthly insights. Concise. Practical. No spam.</p>
+      <form className="card mt-6" action="https://api.web3forms.com/submit" method="POST">
         <input type="hidden" name="access_key" value="YOUR_WEB3FORMS_KEY" />
-        <label className="block text-sm mb-2">E‑mail</label>
-        <input name="email" required type="email" className="w-full rounded-xl bg-neutral-950 border border-neutral-800 p-3" placeholder="jij@bedrijf.nl" />
-        <button className="btn-primary mt-4" type="submit">Inschrijven</button>
+        <label className="mb-2 block text-sm font-medium text-slate-700">Email</label>
+        <input
+          name="email"
+          required
+          type="email"
+          className="w-full rounded-2xl border border-slate-300 bg-white p-3 text-slate-800 shadow-inner focus:border-atsOcean focus:outline-none focus:ring-2 focus:ring-atsOcean/70"
+          placeholder="you@company.com"
+        />
+        <button className="btn-primary mt-4" type="submit">
+          Subscribe
+        </button>
       </form>
     </div>
   )

--- a/app/playbooks/baseline-management/page.tsx
+++ b/app/playbooks/baseline-management/page.tsx
@@ -1,9 +1,12 @@
 export const metadata = { title: "Playbook: Baseline Management — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Playbook: Baseline Management</h1>
-      <p>Een praktische gids voor consistente Microsoft 365 tenants.</p>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">Playbook: Baseline Management</h1>
+      <p>
+        A practical guide to standardise Microsoft 365 tenants and keep customer environments in
+        sync. Full release coming soon.
+      </p>
     </div>
   )
 }

--- a/app/playbooks/page.tsx
+++ b/app/playbooks/page.tsx
@@ -1,9 +1,12 @@
 export const metadata = { title: "Playbooks — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Playbooks</h1>
-      <p>Downloadbare gidsen en frameworks. Binnenkort meer.</p>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">Playbooks</h1>
+      <p>
+        Downloadable guides and frameworks designed to turn research into action. Our first
+        playbooks are in production — subscribe to get notified when they launch.
+      </p>
     </div>
   )
 }

--- a/app/research/dutch-msp-landscape-2025/page.tsx
+++ b/app/research/dutch-msp-landscape-2025/page.tsx
@@ -1,9 +1,12 @@
 export const metadata = { title: "Dutch MSP Landscape 2025 — Preview — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Dutch MSP Landscape 2025 — Preview</h1>
-      <p>Korte preview. Volledige publicatie volgt.</p>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">Dutch MSP Landscape 2025 — Preview</h1>
+      <p>
+        A short preview of the data and takeaways that will be published in the full report. Access
+        the community for early insights and methodology notes.
+      </p>
     </div>
   )
 }

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,9 +1,12 @@
 export const metadata = { title: "Research — Above The Stack" };
 export default function Page() {
   return (
-    <div className="prose prose-invert max-w-none">
-      <h1>Research</h1>
-      <p>Artikelen, rapporten en benchmarks. Binnenkort meer.</p>
+    <div className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
+      <h1 className="h1 text-atsMidnight">Research</h1>
+      <p>
+        Deep dives, market maps, and benchmarks that help MSPs understand where the industry is
+        heading. New publications are on the way.
+      </p>
     </div>
   )
 }

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,8 +1,11 @@
 import Link from 'next/link'
 export default function Card({ title, href, children }:{ title:string, href:string, children?:React.ReactNode }) {
   return (
-    <Link href={href} className="card block hover:border-neutral-700 transition">
-      <h3 className="font-semibold">{title}</h3>
+    <Link
+      href={href}
+      className="card block transition duration-200 hover:-translate-y-1 hover:border-atsOcean/40 hover:shadow-glow"
+    >
+      <h3 className="text-lg font-semibold text-atsMidnight">{title}</h3>
       {children && <p className="muted mt-2 line-clamp-3">{children}</p>}
     </Link>
   )

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,13 +1,19 @@
 export default function Hero() {
   return (
-    <section className="py-12 md:py-20 text-center">
-      <h1 className="h1">Above The Stack</h1>
-      <p className="mt-4 max-w-3xl mx-auto text-lg muted">
-        Independent insights, practical playbooks, and a trusted community for 
-        Managed Service Providers. Launching in Europe with a focus on digital 
-        sovereignty — built to scale globally.
+    <section className="relative overflow-hidden rounded-[2.5rem] border border-white/0 bg-white/80 px-6 py-16 text-center shadow-glow backdrop-blur-sm md:px-12 md:py-24">
+      <div className="absolute -top-24 left-1/2 h-72 w-72 -translate-x-1/2 rounded-full bg-atsSky/40 blur-3xl" />
+      <div className="absolute -bottom-36 left-0 h-80 w-80 -translate-x-1/2 rounded-full bg-atsCoral/30 blur-3xl" />
+      <div className="absolute -bottom-24 right-0 h-72 w-72 translate-x-1/3 rounded-full bg-atsOcean/30 blur-3xl" />
+
+      <h1 className="h1 bg-gradient-to-r from-atsSky via-atsOcean to-atsCoral bg-clip-text text-transparent">
+        Above The Stack
+      </h1>
+      <p className="mx-auto mt-4 max-w-3xl text-lg text-slate-700">
+        Independent insights, practical playbooks, and a trusted community for Managed Service
+        Providers. Launching in Europe with a focus on digital sovereignty — built to scale
+        globally.
       </p>
-      <div className="mt-8 flex flex-wrap gap-4 justify-center">
+      <div className="mt-10 flex flex-wrap justify-center gap-4">
         <a className="btn-primary" href="/playbooks">
           Explore Playbooks
         </a>

--- a/components/LatestThreads.tsx
+++ b/components/LatestThreads.tsx
@@ -3,16 +3,40 @@ import useSWR from 'swr'
 
 const fetcher = (url:string) => fetch(url).then(r => r.json())
 
+const formatDate = (value?: string) => {
+  if (!value) return '—'
+  const parsed = new Date(value)
+  if (Number.isNaN(parsed.getTime())) {
+    return value.slice(0, 10)
+  }
+  return parsed.toLocaleDateString('en-GB', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
 export default function LatestThreads() {
   const { data, error, isLoading } = useSWR('/api/discourse/latest', fetcher, { revalidateOnFocus: false })
-  if (error) return <div className="card">Kan threads niet laden.</div>
-  if (isLoading) return <div className="card">Laden…</div>
+  if (error) return <div className="card">Unable to load the latest threads.</div>
+  if (isLoading) return <div className="card">Loading…</div>
+  if (!data?.length) {
+    return (
+      <div className="card">
+        No community conversations yet. Be among the first to share insights in the portal.
+      </div>
+    )
+  }
   return (
     <div className="grid md:grid-cols-2 gap-4">
       {data.map((t:any) => (
-        <a key={t.id} href={`${process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}/t/${t.slug}/${t.id}`} className="card hover:border-neutral-700">
-          <div className="font-medium">{t.title}</div>
-          <div className="muted mt-1 text-xs">Laatste activiteit: {t.last_posted_at?.slice(0,10) || '—'}</div>
+        <a
+          key={t.id}
+          href={`${process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}/t/${t.slug}/${t.id}`}
+          className="card transition duration-200 hover:-translate-y-1 hover:border-atsOcean/40 hover:shadow-glow"
+        >
+          <div className="font-medium text-atsMidnight">{t.title}</div>
+          <div className="muted mt-1 text-xs">Last activity: {formatDate(t.last_posted_at)}</div>
         </a>
       ))}
     </div>

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,13 +1,13 @@
 export default function Section({ title, subtitle, children }:{ title:string, subtitle?:string, children:React.ReactNode }) {
   return (
-    <section className="mt-12">
-      <div className="flex items-end justify-between mb-4">
+    <section className="mt-16">
+      <div className="mb-6 flex items-end justify-between">
         <div>
-          <h2 className="h2">{title}</h2>
-          {subtitle && <p className="muted mt-1">{subtitle}</p>}
+          <h2 className="h2 text-atsMidnight">{title}</h2>
+          {subtitle && <p className="muted mt-1 max-w-2xl">{subtitle}</p>}
         </div>
       </div>
-      <div className="grid md:grid-cols-3 gap-4">
+      <div className="grid gap-4 md:grid-cols-3">
         {children}
       </div>
     </section>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,12 +8,17 @@ export default {
   theme: {
     extend: {
       colors: {
-        atsRed: "#E01949",
-        atsViolet: "#6D28D9",
+        atsSky: "#33C7FF",
+        atsOcean: "#2641D6",
+        atsMidnight: "#0F1F4B",
+        atsCoral: "#FF7A59",
       },
       backgroundImage: {
-        'grid': "radial-gradient(circle at 1px 1px, rgba(255,255,255,0.07) 1px, transparent 0)",
-      }
+        grid: "radial-gradient(circle at 1px 1px, rgba(15,31,75,0.08) 1px, transparent 0)",
+      },
+      boxShadow: {
+        glow: "0 25px 60px -15px rgba(38,65,214,0.25)",
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- restyled the global theme with a light Above The Stack palette, gradients, and updated button/card treatments
- refreshed navigation, hero, and community widgets to match the new aesthetic and improve thread messaging
- translated the site content and README into English with updated copy across secondary pages

## Testing
- `npx eslint --max-warnings=0 . --ext .js,.jsx,.ts,.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68d070b218848327addbb68f297bf708