### PR TITLE
Refresh copy to emphasise member-led Above The Stack community

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,7 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
 import MemberCard from '@/components/MemberCard'
-import { foundingMembers } from '@/data/foundingMembers'
+import { leadershipTeam } from '@/data/leadershipTeam'
 
 export const metadata = { title: 'About — Above The Stack' }
 
@@ -48,13 +48,12 @@ export default function Page() {
           knowledge without the noise.
         </p>
         <p>
-          The initiative is led by four founding members with deep roots in the MSP and channel
-          ecosystem, each bringing unique expertise and prior community experience. They help steward
-          Above Connect — our private member portal — and ensure every conversation stays anchored in
-          real operator needs.
+          The initiative is stewarded by the Above The Stack Leadership Team — Ashley Schut, Tycho
+          Löke, Pierre Kleine-Schaars, and Timon Bergsma. Their role is to ensure every member’s voice
+          is heard, documented, and turned into action inside Above Connect.
         </p>
         <div className="grid gap-6 pt-4 sm:grid-cols-2">
-          {foundingMembers.map((member) => (
+          {leadershipTeam.map((member) => (
             <MemberCard key={member.name} member={member} />
           ))}
         </div>

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -38,12 +38,20 @@ export default function Page() {
             benchmarks you need next. Every conversation is searchable, accountable, and led by the
             community.
           </p>
+          <p className="text-lg leading-relaxed">
+            Company membership is €150 per year per MSP, giving every team member a seat. Vendors and
+            ISVs join as partners in a sales-neutral, knowledge-sharing capacity by requesting
+            curated access.
+          </p>
           <div className="flex flex-wrap gap-3">
-            <a className="btn-primary" href={portalUrl}>
-              Member login
+            <a className="btn-primary" href={`${portalUrl}/signup`}>
+              Become a Member
             </a>
-            <a className="btn-ghost" href={`${portalUrl}/signup`}>
-              Request an invite
+            <a className="btn-ghost" href="mailto:partnerships@abovethestack.com">
+              Request an Invite
+            </a>
+            <a className="btn-ghost" href={portalUrl}>
+              Log in to Above Connect
             </a>
             <a className="btn-ghost" href="mailto:community@abovethestack.com">
               Talk to a moderator
@@ -118,8 +126,9 @@ export default function Page() {
         title="Join in three steps"
         columns="three"
       >
-        <Card title="1. Apply or log in" cta="Go to portal" href={portalUrl}>
-          MSPs join for free. Vendors and partners can request an invite so we keep the space curated.
+        <Card title="1. Become a member" cta="Become a Member" href={`${portalUrl}/signup`}>
+          Membership is €150 per company and covers every teammate. Vendors and partners use the same
+          flow to request curated, sales-neutral participation.
         </Card>
         <Card title="2. Complete your profile">
           Share your role, region, and focus areas. We use this to recommend discussions and small

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 Explore Above Connect
               </Link>
               <Link className="btn-primary text-sm shadow-none" href={portalUrl}>
-                Member login
+                Log in to Above Connect
               </Link>
             </div>
           </div>
@@ -96,7 +96,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <h3 className="text-sm font-semibold text-atsMidnight">Stay connected</h3>
               <div className="flex flex-col gap-2">
                 <Link className="transition hover:text-atsOcean" href={portalUrl}>
-                  Member login
+                  Log in to Above Connect
                 </Link>
                 <Link className="transition hover:text-atsOcean" href="/contact">
                   Contact

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -10,18 +10,25 @@ export default function Page() {
     <div className="space-y-24">
       <section className="mx-auto max-w-3xl space-y-6 text-lg leading-relaxed text-slate-700">
         <span className="eyebrow">Member access</span>
-        <h1 className="h1 text-balance text-atsMidnight">Log in to Above The Stack</h1>
+        <h1 className="h1 text-balance text-atsMidnight">Log in to Above Connect</h1>
         <p>
           The newsletter has evolved into our community digest. Log in to the member portal to access
           research drops, playbooks in progress, and the weekly summary of what happened inside Above
           Connect.
         </p>
+        <p>
+          Company membership is €150 per year, unlocking access for every teammate. Vendors and ISVs
+          can request curated participation so conversations stay collaborative and sales-neutral.
+        </p>
         <div className="flex flex-wrap gap-3">
           <a className="btn-primary" href={portalUrl}>
-            Member login
+            Log in to Above Connect
           </a>
           <a className="btn-ghost" href={`${portalUrl}/signup`}>
-            Request an invite
+            Become a Member
+          </a>
+          <a className="btn-ghost" href="mailto:partnerships@abovethestack.com">
+            Request an Invite
           </a>
         </div>
       </section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Section from '@/components/Section'
 import Card from '@/components/Card'
 import LatestThreads from '@/components/LatestThreads'
 import MemberCard from '@/components/MemberCard'
-import { foundingMembers } from '@/data/foundingMembers'
+import { leadershipTeam } from '@/data/leadershipTeam'
 
 export default function HomePage() {
   const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
@@ -60,8 +60,8 @@ export default function HomePage() {
           templates, customer messaging, and board-ready metrics.
         </Card>
         <Card title="Peer accountability">
-          Join Above Connect, our moderated member portal where MSPs, vendors, and ecosystem
-          partners work through similar challenges in public.
+          Join Above Connect, our moderated member portal where MSPs work through shared challenges
+          in public while vendors and ISVs contribute as sales-neutral partners.
         </Card>
       </Section>
 
@@ -79,7 +79,7 @@ export default function HomePage() {
         columns="two"
         action={
           <a className="btn-ghost" href={`${portalUrl}/signup`}>
-            Become a member
+            Become a Member
           </a>
         }
       >
@@ -100,8 +100,9 @@ export default function HomePage() {
             </li>
           </ul>
           <div className="rounded-2xl bg-atsOcean/5 p-4 text-sm text-atsMidnight">
-            Verified MSPs get instant access to Above Connect. Vendors can request participation to
-            collaborate in dedicated partner lounges.
+            Company membership is €150 per year with space for every teammate. Verified MSPs receive
+            direct access to Above Connect, while vendors participate by requesting partner lounges
+            and sharing knowledge without a sales pitch.
           </div>
         </div>
         <LatestThreads />
@@ -120,7 +121,7 @@ export default function HomePage() {
           Monthly broadcast deep dives reviewing our latest datasets, with Q&A directly inside the
           community afterwards.
         </Card>
-        <Card title="Partner workshops" href="/community" cta="Request an invite">
+        <Card title="Partner workshops" href="/community" cta="Request an Invite">
           Vendors collaborate with MSPs on real go-to-market motions, stress testing value props and
           co-selling agreements.
         </Card>
@@ -131,12 +132,55 @@ export default function HomePage() {
       </Section>
 
       <Section
-        eyebrow="Founding members"
-        title="Meet the Above Connect founding cohort"
-        description="These community builders steward Above Connect and keep the experience grounded in MSP reality."
+        eyebrow="By Members, For Members"
+        title="The community runs on open contributions and peer-driven growth"
+        description="Every company member can propose research, shape playbooks, and host sessions that keep the MSP agenda front and centre — every voice is welcomed and respected."
+        columns="three"
+      >
+        <Card title="Open contributions">
+          Share briefs, templates, and questions directly inside Above Connect. The community votes on
+          what ships next, and leadership turns the most-requested ideas into programmes.
+        </Card>
+        <Card title="Peer accountability">
+          Members challenge each other in the open, report back on outcomes, and elevate the playbooks
+          with real-world proof so everyone keeps growing faster together.
+        </Card>
+        <Card title="Neutral guardrails">
+          Our rules keep discussions fair and sales-neutral. Everyone participates under their company
+          name and earns trust by respecting time, context, and transparency.
+        </Card>
+      </Section>
+
+      <Section
+        eyebrow="Channel Context"
+        title="Putting MSPs at the heart of the IT channel"
+        description={
+          <>
+            In our eyes, the MSP is the most important player in the channel because they are closest
+            to the customer and deliver the services that make everything work.
+          </>
+        }
         columns="two"
       >
-        {foundingMembers.map((member) => (
+        <Card title="What the channel means here">
+          We cover the entire ecosystem of vendors, distributors, marketplaces, consultants, and the
+          service providers connecting it all. Above The Stack tracks how these forces converge around
+          the customer.
+        </Card>
+        <Card title="Who we call an MSP">
+          MSPs, MSSPs, MIPs, SPs, and consultancies building managed offerings are welcome. If your
+          team delivers ongoing services that keep customers secure, productive, and informed, you
+          belong inside Above Connect.
+        </Card>
+      </Section>
+
+      <Section
+        eyebrow="Leadership Team"
+        title="Meet the Above The Stack Leadership Team"
+        description="Ashley Schut, Tycho Löke, Pierre Kleine-Schaars, and Timon Bergsma ensure every member’s voice is heard and turned into action."
+        columns="two"
+      >
+        {leadershipTeam.map((member) => (
           <MemberCard key={member.name} member={member} />
         ))}
       </Section>
@@ -147,19 +191,32 @@ export default function HomePage() {
             <div className="space-y-4">
               <span className="eyebrow text-white/70">Launch cohort</span>
               <h2 className="text-3xl font-semibold tracking-tight text-balance">
-                Join Above The Stack as a founding member
+                Join Above The Stack as a member
               </h2>
               <p className="text-sm leading-relaxed text-white/80">
-                Membership is free for MSPs. Vendors and partners can request access to collaborate
-                transparently. Log in to Above Connect or request an invite and we’ll set you up.
+                Membership is €150 per year per company, and every team member is included. Vendors
+                and ISVs can request partner access as long as they contribute in a sales-neutral,
+                knowledge-sharing role.
               </p>
             </div>
             <div className="space-y-3">
-              <a className="btn-primary w-full justify-center bg-white text-atsMidnight hover:opacity-90" href={portalUrl}>
-                Member login
+              <a
+                className="btn-primary w-full justify-center bg-white text-atsMidnight hover:opacity-90"
+                href={`${portalUrl}/signup`}
+              >
+                Become a Member
               </a>
-              <a className="btn-ghost w-full justify-center border-white/30 bg-white/10 text-white hover:bg-white/20" href={`${portalUrl}/signup`}>
-                Request an invite
+              <a
+                className="btn-ghost w-full justify-center border-white/30 bg-white/10 text-white hover:bg-white/20"
+                href="mailto:partnerships@abovethestack.com"
+              >
+                Request an Invite
+              </a>
+              <a
+                className="btn-ghost w-full justify-center border-white/30 bg-white/10 text-white hover:bg-white/20"
+                href={portalUrl}
+              >
+                Log in to Above Connect
               </a>
             </div>
           </div>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -22,7 +22,7 @@ export default function Hero() {
           </div>
           <div className="flex flex-wrap gap-3">
             <a className="btn-primary" href={portalUrl}>
-              Member login
+              Log in to Above Connect
             </a>
             <a className="btn-ghost" href="/community">
               Tour the community

--- a/components/MemberCard.tsx
+++ b/components/MemberCard.tsx
@@ -1,8 +1,8 @@
 import Image from 'next/image'
-import type { FoundingMember } from '@/data/foundingMembers'
+import type { LeadershipMember } from '@/data/leadershipTeam'
 
 type MemberCardProps = {
-  member: FoundingMember
+  member: LeadershipMember
 }
 
 export default function MemberCard({ member }: MemberCardProps) {

--- a/data/leadershipTeam.ts
+++ b/data/leadershipTeam.ts
@@ -1,4 +1,4 @@
-export type FoundingMember = {
+export type LeadershipMember = {
   name: string
   role: string
   region: string
@@ -27,7 +27,7 @@ const createMonogramHeadshot = (initials: string, gradient: [string, string]) =>
   return `data:image/svg+xml,${encodeURIComponent(svg)}`
 }
 
-export const foundingMembers: FoundingMember[] = [
+export const leadershipTeam: LeadershipMember[] = [
   {
     name: 'Tycho Löke',
     role: 'Channel Pre-Sales Solutions Engineer @ AvePoint',


### PR DESCRIPTION
## Summary
- rewrite the homepage to centre member-led messaging, add by-members and channel context sections, and reposition the leadership team and launch cohort copy
- update community, newsletter, and sitewide navigation CTAs to reflect the €150 company membership model and partner invite process
- rename the founding members data to leadership team and ensure references across the site celebrate their role in amplifying member voices

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d083597c18832787ed48e56c0588db