### PR TITLE
Replace emojis with brand-aligned iconography

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,29 +2,32 @@ import Card from '@/components/Card'
 import Section from '@/components/Section'
 import MemberCard from '@/components/MemberCard'
 import { leadershipTeam } from '@/data/leadershipTeam'
+import { Compass, FlaskConical, Scale, Sparkles, UsersRound } from 'lucide-react'
 
 export const metadata = { title: 'About — Above The Stack' }
+
+const iconClass = 'h-5 w-5 text-atsMidnight'
 
 const differentiators = [
   {
     title: 'MSP-first, always',
     description: 'Every programme, playbook, and decision is shaped by MSP operators. Partners participate in support of member outcomes.',
-    icon: '🧭',
+    icon: <Compass aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Independent & neutral',
     description: 'No single vendor funds the agenda. Guardrails keep discussions transparent, accountable, and sales-neutral.',
-    icon: '⚖️',
+    icon: <Scale aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Practical & open',
     description: 'We ship research and playbooks iteratively with member feedback baked in, not theory written in a vacuum.',
-    icon: '🧪',
+    icon: <FlaskConical aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Community-powered',
     description: 'Moderators curate, but members lead. Anyone can propose research, facilitate sessions, or contribute assets.',
-    icon: '🤲',
+    icon: <UsersRound aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -56,7 +59,7 @@ export default function Page() {
     <div className="space-y-24">
       <section className="glass-panel mx-auto max-w-5xl space-y-6 px-10 py-14 text-lg leading-relaxed text-slate-700">
         <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80">
-          <span aria-hidden>👋</span> Our mission
+          <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Our mission
         </span>
         <h1 className="h1 text-balance text-atsMidnight">Building the independent, MSP-first community</h1>
         <p>

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -2,26 +2,37 @@ import Card from '@/components/Card'
 import LatestThreads from '@/components/LatestThreads'
 import Section from '@/components/Section'
 import { communityCommitments } from '@/data/community'
+import {
+  ClipboardList,
+  Compass,
+  Handshake,
+  MessageCircle,
+  Sparkles,
+  WandSparkles,
+  Wrench,
+} from 'lucide-react'
 
 export const metadata = { title: 'Community — Above The Stack' }
 
 const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
+const iconClass = 'h-5 w-5 text-atsMidnight'
+
 const lounges = [
   {
     title: 'Operator lounge',
     description: 'MSP founders and leadership teams swap pricing experiments, customer success tactics, and hiring frameworks.',
-    icon: '🧭',
+    icon: <Compass aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Service delivery guild',
     description: 'Technicians and delivery leads compare tooling stacks, workflow automations, and resilient operations.',
-    icon: '🛠️',
+    icon: <Wrench aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Partner strategy space',
     description: 'Solution and distribution teams co-design launch plans, explore MDF collaborations, and gather honest product feedback under neutral guardrails.',
-    icon: '🤝',
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -53,17 +64,17 @@ const steps = [
     description: 'Membership is €150 / $165 per company and covers every teammate. Partners use the same flow to request curated, sales-neutral participation.',
     href: `${portalUrl}/signup`,
     cta: 'Become a Member',
-    icon: '🪄',
+    icon: <WandSparkles aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Complete your profile',
     description: 'Share your role, region, and focus areas so moderators can recommend discussions and connect you with peers.',
-    icon: '🧾',
+    icon: <ClipboardList aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Engage with intent',
     description: 'Introduce yourself, react to a prompt, or request feedback on a challenge. The more context you give, the richer the responses.',
-    icon: '💬',
+    icon: <MessageCircle aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -73,7 +84,7 @@ export default function Page() {
       <section className="relative grid gap-12 rounded-[2.5rem] border border-white/70 bg-white/80 p-10 shadow-[0_32px_70px_-35px_rgba(15,31,75,0.55)] backdrop-blur-xl lg:grid-cols-[1.2fr_1fr]">
         <div className="space-y-6 text-slate-700">
           <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80">
-            <span aria-hidden>👋</span> Above Connect
+            <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Above Connect
           </span>
           <h1 className="h1 text-balance text-atsMidnight">A private, high-signal portal for MSPs and trusted partners</h1>
           <p className="text-lg leading-relaxed">

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,5 +1,6 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
+import { Handshake, Lightbulb, Presentation, UsersRound } from 'lucide-react'
 
 export const metadata = { title: 'Events & Roundtables — Above The Stack' }
 
@@ -26,21 +27,23 @@ const sessions = [
   },
 ]
 
+const iconClass = 'h-5 w-5 text-atsMidnight'
+
 const formats = [
   {
     title: 'Operator roundtables',
     description: 'Curated rooms of 10–12 MSP leaders facilitated by Above The Stack. Expect candid discussions and shared documents.',
-    icon: '🗣️',
+    icon: <UsersRound aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Research briefings',
     description: 'Live walkthroughs of upcoming reports with the analysts who produced them, plus access to the working datasets.',
-    icon: '📡',
+    icon: <Presentation aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Partner workshops',
     description: 'Co-creation sessions pairing MSPs with vendors to stress test roadmaps and improve go-to-market motions.',
-    icon: '🤝',
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -89,10 +92,20 @@ export default function Page() {
       </Section>
 
       <Section eyebrow="Host with us" title="Bring your topic to the Above The Stack community" columns="two">
-        <Card title="Submit a session idea" href="mailto:events@abovethestack.com" cta="Share your proposal" icon="💡">
+        <Card
+          title="Submit a session idea"
+          href="mailto:events@abovethestack.com"
+          cta="Share your proposal"
+          icon={<Lightbulb aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+        >
           We welcome ideas from members and partners. Tell us the challenge you want to unpack, the audience you hope to gather, and what success looks like.
         </Card>
-        <Card title="Partner opportunities" href="mailto:partnerships@abovethestack.com" cta="Discuss collaboration" icon="🤝">
+        <Card
+          title="Partner opportunities"
+          href="mailto:partnerships@abovethestack.com"
+          cta="Discuss collaboration"
+          icon={<Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+        >
           Vendors can co-host educational sessions. We work with you to keep the content practical and bias-free.
         </Card>
       </Section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,8 +4,32 @@ import Card from '@/components/Card'
 import LatestThreads from '@/components/LatestThreads'
 import MemberCard from '@/components/MemberCard'
 import { leadershipTeam } from '@/data/leadershipTeam'
+import {
+  BarChart3,
+  BrainCircuit,
+  CalendarClock,
+  Compass,
+  Globe2,
+  Handshake,
+  Library,
+  Lightbulb,
+  MicVocal,
+  Puzzle,
+  Radar,
+  RadioTower,
+  Satellite,
+  SatelliteDish,
+  Search,
+  ShieldCheck,
+  ShieldHalf,
+  Sparkles,
+  UsersRound,
+  Vote,
+} from 'lucide-react'
 
 const defaultPortalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
+
+const iconClass = 'h-5 w-5 text-atsMidnight'
 
 const upcomingHighlights = [
   {
@@ -16,7 +40,7 @@ const upcomingHighlights = [
     href: '/research',
     cta: 'Read the outline',
     className: 'border-transparent bg-gradient-to-br from-white via-atsSky/15 to-atsOcean/10',
-    icon: '📊',
+    icon: <BarChart3 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     eyebrow: 'Playbook',
@@ -25,7 +49,7 @@ const upcomingHighlights = [
       'Implementation workflows, customer comms, and pricing guidance created by operators already living the directive.',
     href: '/playbooks',
     cta: 'See the chapters',
-    icon: '🛡️',
+    icon: <ShieldCheck aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     eyebrow: 'Roundtable',
@@ -35,7 +59,7 @@ const upcomingHighlights = [
     href: '/events',
     cta: 'Reserve your seat',
     className: 'border-transparent bg-gradient-to-br from-white via-atsCoral/20 to-atsSky/10',
-    icon: '🤝',
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -43,17 +67,17 @@ const memberDesigned = [
   {
     title: 'Signals shaped by peers',
     description: 'Members vote on the research we publish, share data, and co-author playbooks that are reviewed in the open.',
-    icon: '🗳️',
+    icon: <Vote aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Transparent collaboration',
     description: 'Every conversation happens under real names with context so operators can learn together, not in silos.',
-    icon: '🔍',
+    icon: <Search aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Global reach, local nuance',
     description: 'Chapters across EMEA, North America, and APAC compare regulation, pricing pressure, and service design.',
-    icon: '🌍',
+    icon: <Globe2 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -61,22 +85,22 @@ const membershipBenefits = [
   {
     title: 'All employees included',
     description: 'One €150/year company membership covers your whole team with local currency equivalents.',
-    icon: '👥',
+    icon: <UsersRound aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
   {
     title: 'Guided onboarding',
     description: 'Meet moderators, get recommendations for lounges, and receive a personal Above Connect orientation.',
-    icon: '🧭',
+    icon: <Compass aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
   {
     title: 'Living library',
     description: 'Research, playbooks, and templates are refreshed as the community reports back on what works.',
-    icon: '📚',
+    icon: <Library aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
   {
     title: 'Member-led programmes',
     description: 'Roundtables, office hours, and partner workshops run every month — all recorded inside Above Connect.',
-    icon: '🎙️',
+    icon: <MicVocal aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
 ]
 
@@ -84,27 +108,27 @@ const whyMsps = [
   {
     title: 'Managed Service Providers (MSPs)',
     description: 'Deliver the ongoing customer experience, run the stack, and keep clients productive. You sit at the heart of every decision we make.',
-    icon: '💡',
+    icon: <Lightbulb aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Managed Security Service Providers (MSSPs)',
     description: 'Bring deep security expertise, compliance stewardship, and incident response knowledge that strengthens the whole community.',
-    icon: '🛡️',
+    icon: <ShieldHalf aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Managed Infrastructure Providers (MIPs)',
     description: 'Operate critical infrastructure, cloud, and connectivity that power digital businesses — your insights shape our playbooks.',
-    icon: '🛰️',
+    icon: <SatelliteDish aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Service Providers (SPs)',
     description: 'From telecom to vertical IT specialists, your service delivery models keep customers connected and confident.',
-    icon: '📡',
+    icon: <RadioTower aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Consultancies & advisors',
     description: 'Advisors who build managed offerings or guide MSPs on transformation are welcome. Bring your frameworks and learnings.',
-    icon: '🧠',
+    icon: <BrainCircuit aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -135,28 +159,28 @@ const programs = [
     description: '12-person rooms moderated by the editorial team to unpack pricing, delivery, and growth bets with peers.',
     href: '/events',
     cta: 'Explore sessions',
-    icon: '🧩',
+    icon: <Puzzle aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Research briefings',
     description: 'Monthly walkthroughs of upcoming reports with the analysts and members who provided the data.',
     href: '/research',
     cta: 'Get notified',
-    icon: '🛰️',
+    icon: <Radar aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Partner workshops',
     description: 'Neutral collaboration spaces where vendors, distributors, and MSPs stress test roadmaps.',
     href: '/community',
     cta: 'Request an invite',
-    icon: '🤝',
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Office hours',
     description: 'Weekly clinics with members and moderators to debug tooling, share dashboards, and swap templates.',
     href: `${defaultPortalUrl}/latest`,
     cta: 'See schedule',
-    icon: '🗓️',
+    icon: <CalendarClock aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -215,9 +239,9 @@ export default function HomePage() {
             </p>
           </div>
           <div className="space-y-3 text-sm text-slate-600">
-            <div className="flex items-center gap-2 text-atsMidnight">
-              <span className="text-lg" aria-hidden>
-                ✨
+            <div className="flex items-center gap-3 text-atsMidnight">
+              <span className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-atsOcean/10 text-atsOcean">
+                <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
               </span>
               Your MSP community is waiting inside Above Connect.
             </div>
@@ -237,7 +261,7 @@ export default function HomePage() {
               key={benefit.title}
               className="card flex items-start gap-4 border-white/70 bg-white/90 p-5 text-left shadow-[0_25px_60px_-48px_rgba(15,31,75,0.6)]"
             >
-              <span className="mt-1 text-2xl" aria-hidden>
+              <span className="mt-1 inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-xl bg-atsOcean/10 text-atsOcean">
                 {benefit.icon}
               </span>
               <div className="space-y-1">

--- a/app/playbooks/page.tsx
+++ b/app/playbooks/page.tsx
@@ -1,25 +1,37 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
+import {
+  Bot,
+  ChartSpline,
+  FileText,
+  Lightbulb,
+  MessagesSquare,
+  PenLine,
+  ScrollText,
+  Toolbox,
+} from 'lucide-react'
 
 export const metadata = { title: 'Playbooks — Above The Stack' }
 
 const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
+const iconClass = 'h-5 w-5 text-atsMidnight'
+
 const playbooks = [
   {
     title: 'NIS2 readiness kit',
     description: 'Gap assessment templates, customer comms, and service packaging guidance to operationalise the directive.',
-    icon: '🧾',
+    icon: <ScrollText aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'AI service launch framework',
     description: 'Positioning, pricing, and delivery runbooks for rolling out AI-enabled support without eroding trust.',
-    icon: '🤖',
+    icon: <Bot aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Customer success dashboard',
     description: 'A full measurement model linking support signals to retention, expansion, and advocacy metrics.',
-    icon: '📊',
+    icon: <ChartSpline aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -27,17 +39,17 @@ const whatsInside = [
   {
     title: 'Executive summary',
     description: 'A concise readout distilling the why, the opportunity, and the pitfalls — ready to share with leadership and partners.',
-    icon: '🧠',
+    icon: <FileText aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Implementation toolkit',
     description: 'Templates, checklists, and SOPs to plug directly into your PSA, documentation, and customer success workflows.',
-    icon: '🧰',
+    icon: <Toolbox aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Community feedback loop',
     description: 'Dedicated Above Connect threads to surface questions, share outcomes, and collectively improve the material.',
-    icon: '💬',
+    icon: <MessagesSquare aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -81,10 +93,20 @@ export default function Page() {
       </Section>
 
       <Section eyebrow="Contribute" title="Help us build the next playbook" columns="two">
-        <Card title="Suggest a topic" href="mailto:hello@abovethestack.com" cta="Submit an idea" icon="💡">
+        <Card
+          title="Suggest a topic"
+          href="mailto:hello@abovethestack.com"
+          cta="Submit an idea"
+          icon={<Lightbulb aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+        >
           Let us know which challenge you want solved next. We co-create outlines with members and invite operators to share their working documents.
         </Card>
-        <Card title="Become a reviewer" href={`${portalUrl}/groups/reviewers`} cta="Join the reviewer group" icon="📝">
+        <Card
+          title="Become a reviewer"
+          href={`${portalUrl}/groups/reviewers`}
+          cta="Join the reviewer group"
+          icon={<PenLine aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+        >
           Review drafts ahead of release, contribute examples, and receive shout-outs in the published editions.
         </Card>
       </Section>

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,25 +1,38 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
+import {
+  BarChart3,
+  ClipboardCheck,
+  Globe2,
+  Handshake,
+  Map,
+  RefreshCcw,
+  ScrollText,
+  ShieldCheck,
+  UsersRound,
+} from 'lucide-react'
 
 export const metadata = { title: 'Research — Above The Stack' }
 
 const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
+const iconClass = 'h-5 w-5 text-atsMidnight'
+
 const pillars = [
   {
     title: 'Market intelligence',
     description: 'Sizing, growth trajectories, and economics behind MSP service lines and partner ecosystems across regions.',
-    icon: '🌐',
+    icon: <Globe2 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Regulation & compliance',
     description: 'Breakdowns of NIS2, DORA, and local regulations paired with implementation implications for MSP teams.',
-    icon: '📜',
+    icon: <ScrollText aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Operating benchmarks',
     description: 'Metrics on delivery efficiency, customer acquisition costs, and tooling adoption to guide investments.',
-    icon: '📈',
+    icon: <BarChart3 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -27,17 +40,17 @@ const releases = [
   {
     title: 'Global MSP Landscape 2025',
     description: 'Service mix, profitability signals, and competitive positioning across 120+ MSPs in multiple regions.',
-    icon: '🗺️',
+    icon: <Map aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Vendor Relationship Pulse',
     description: 'How MSPs evaluate vendor partners, MDF programmes, and co-selling expectations for the year ahead.',
-    icon: '🤝',
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'State of Managed Security',
     description: 'Pricing models, staffing, and incident response capabilities for security-centric MSP offerings.',
-    icon: '🛡️',
+    icon: <ShieldCheck aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -45,22 +58,22 @@ const methodology = [
   {
     title: 'Community-led',
     description: 'Surveys and interviews originate from member questions. We vet every data contributor and anonymise results.',
-    icon: '🧭',
+    icon: <UsersRound aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Transparent & iterative',
     description: 'Draft findings are posted in Above Connect for feedback. Members challenge assumptions before publication.',
-    icon: '🔄',
+    icon: <RefreshCcw aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Practical outcomes',
     description: 'Each report includes actions, metrics to monitor, and supporting templates so teams can implement fast.',
-    icon: '🛠️',
+    icon: <ClipboardCheck aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Global relevance',
     description: 'We compare insights with MSPs worldwide to highlight regional differences and transferable learnings.',
-    icon: '🌍',
+    icon: <Globe2 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Sparkles } from 'lucide-react'
 import { communityCommitments } from '@/data/community'
 
 const heroStats = [
@@ -20,7 +21,7 @@ export default function Hero() {
         <div className="space-y-10 text-left">
           <div className="space-y-5">
             <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80 shadow-inner">
-              <span aria-hidden>👋</span> Welcome to Above The Stack
+              <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Welcome to Above The Stack
             </span>
             <h1 className="h1 text-balance text-atsMidnight">
               Your MSP community is waiting

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "above-the-stack",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.544.0",
         "next": "14.2.11",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -3922,6 +3923,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "lucide-react": "^0.544.0",
     "next": "14.2.11",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
## Summary
- replace emoji markers across the marketing pages with lucide-react icons to deliver consistent brand styling
- restyle membership highlights and hero/community badges to showcase the new icons within branded containers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d099ac9d4883278274e941e15cbae1