### PR TITLE
Polish marketing icon system with reusable badges

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,29 +2,36 @@ import Card from '@/components/Card'
 import Section from '@/components/Section'
 import MemberCard from '@/components/MemberCard'
 import { leadershipTeam } from '@/data/leadershipTeam'
+import { Compass, FlaskConical, Scale, Sparkles, UsersRound } from 'lucide-react'
 
 export const metadata = { title: 'About — Above The Stack' }
+
+const iconClass = 'h-5 w-5'
 
 const differentiators = [
   {
     title: 'MSP-first, always',
     description: 'Every programme, playbook, and decision is shaped by MSP operators. Partners participate in support of member outcomes.',
-    icon: '🧭',
+    iconAccent: 'midnight' as const,
+    icon: <Compass aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Independent & neutral',
     description: 'No single vendor funds the agenda. Guardrails keep discussions transparent, accountable, and sales-neutral.',
-    icon: '⚖️',
+    iconAccent: 'ocean' as const,
+    icon: <Scale aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Practical & open',
     description: 'We ship research and playbooks iteratively with member feedback baked in, not theory written in a vacuum.',
-    icon: '🧪',
+    iconAccent: 'sky' as const,
+    icon: <FlaskConical aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Community-powered',
     description: 'Moderators curate, but members lead. Anyone can propose research, facilitate sessions, or contribute assets.',
-    icon: '🤲',
+    iconAccent: 'coral' as const,
+    icon: <UsersRound aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -56,7 +63,7 @@ export default function Page() {
     <div className="space-y-24">
       <section className="glass-panel mx-auto max-w-5xl space-y-6 px-10 py-14 text-lg leading-relaxed text-slate-700">
         <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80">
-          <span aria-hidden>👋</span> Our mission
+          <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Our mission
         </span>
         <h1 className="h1 text-balance text-atsMidnight">Building the independent, MSP-first community</h1>
         <p>
@@ -126,7 +133,12 @@ export default function Page() {
         columns="two"
       >
         {differentiators.map((item) => (
-          <Card key={item.title} title={item.title} icon={item.icon}>
+          <Card
+            key={item.title}
+            title={item.title}
+            icon={item.icon}
+            iconAccent={item.iconAccent}
+          >
             {item.description}
           </Card>
         ))}

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -2,26 +2,40 @@ import Card from '@/components/Card'
 import LatestThreads from '@/components/LatestThreads'
 import Section from '@/components/Section'
 import { communityCommitments } from '@/data/community'
+import {
+  ClipboardList,
+  Compass,
+  Handshake,
+  MessageCircle,
+  Sparkles,
+  WandSparkles,
+  Wrench,
+} from 'lucide-react'
 
 export const metadata = { title: 'Community — Above The Stack' }
 
 const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
+const iconClass = 'h-5 w-5'
+
 const lounges = [
   {
     title: 'Operator lounge',
     description: 'MSP founders and leadership teams swap pricing experiments, customer success tactics, and hiring frameworks.',
-    icon: '🧭',
+    iconAccent: 'midnight' as const,
+    icon: <Compass aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Service delivery guild',
     description: 'Technicians and delivery leads compare tooling stacks, workflow automations, and resilient operations.',
-    icon: '🛠️',
+    iconAccent: 'ocean' as const,
+    icon: <Wrench aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Partner strategy space',
     description: 'Solution and distribution teams co-design launch plans, explore MDF collaborations, and gather honest product feedback under neutral guardrails.',
-    icon: '🤝',
+    iconAccent: 'coral' as const,
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -53,17 +67,20 @@ const steps = [
     description: 'Membership is €150 / $165 per company and covers every teammate. Partners use the same flow to request curated, sales-neutral participation.',
     href: `${portalUrl}/signup`,
     cta: 'Become a Member',
-    icon: '🪄',
+    iconAccent: 'midnight' as const,
+    icon: <WandSparkles aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Complete your profile',
     description: 'Share your role, region, and focus areas so moderators can recommend discussions and connect you with peers.',
-    icon: '🧾',
+    iconAccent: 'ocean' as const,
+    icon: <ClipboardList aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Engage with intent',
     description: 'Introduce yourself, react to a prompt, or request feedback on a challenge. The more context you give, the richer the responses.',
-    icon: '💬',
+    iconAccent: 'coral' as const,
+    icon: <MessageCircle aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -73,7 +90,7 @@ export default function Page() {
       <section className="relative grid gap-12 rounded-[2.5rem] border border-white/70 bg-white/80 p-10 shadow-[0_32px_70px_-35px_rgba(15,31,75,0.55)] backdrop-blur-xl lg:grid-cols-[1.2fr_1fr]">
         <div className="space-y-6 text-slate-700">
           <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80">
-            <span aria-hidden>👋</span> Above Connect
+            <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Above Connect
           </span>
           <h1 className="h1 text-balance text-atsMidnight">A private, high-signal portal for MSPs and trusted partners</h1>
           <p className="text-lg leading-relaxed">
@@ -141,7 +158,12 @@ export default function Page() {
         description="Membership unlocks themed lounges designed to keep discussions focused and actionable."
       >
         {lounges.map((item) => (
-          <Card key={item.title} title={item.title} icon={item.icon}>
+          <Card
+            key={item.title}
+            title={item.title}
+            icon={item.icon}
+            iconAccent={item.iconAccent}
+          >
             {item.description}
           </Card>
         ))}
@@ -178,6 +200,7 @@ export default function Page() {
             key={step.title}
             title={step.title}
             icon={step.icon}
+            iconAccent={step.iconAccent}
             href={step.href}
             cta={step.cta}
             className={step.href ? 'border-transparent bg-gradient-to-br from-white via-atsSky/15 to-atsOcean/10' : undefined}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,5 +1,6 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
+import { Handshake, Lightbulb, Presentation, UsersRound } from 'lucide-react'
 
 export const metadata = { title: 'Events & Roundtables — Above The Stack' }
 
@@ -26,21 +27,26 @@ const sessions = [
   },
 ]
 
+const iconClass = 'h-5 w-5'
+
 const formats = [
   {
     title: 'Operator roundtables',
     description: 'Curated rooms of 10–12 MSP leaders facilitated by Above The Stack. Expect candid discussions and shared documents.',
-    icon: '🗣️',
+    iconAccent: 'midnight' as const,
+    icon: <UsersRound aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Research briefings',
     description: 'Live walkthroughs of upcoming reports with the analysts who produced them, plus access to the working datasets.',
-    icon: '📡',
+    iconAccent: 'ocean' as const,
+    icon: <Presentation aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Partner workshops',
     description: 'Co-creation sessions pairing MSPs with vendors to stress test roadmaps and improve go-to-market motions.',
-    icon: '🤝',
+    iconAccent: 'coral' as const,
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -82,17 +88,34 @@ export default function Page() {
 
       <Section eyebrow="Formats" title="Choose how you want to collaborate">
         {formats.map((format) => (
-          <Card key={format.title} title={format.title} icon={format.icon}>
+          <Card
+            key={format.title}
+            title={format.title}
+            icon={format.icon}
+            iconAccent={format.iconAccent}
+          >
             {format.description}
           </Card>
         ))}
       </Section>
 
       <Section eyebrow="Host with us" title="Bring your topic to the Above The Stack community" columns="two">
-        <Card title="Submit a session idea" href="mailto:events@abovethestack.com" cta="Share your proposal" icon="💡">
+        <Card
+          title="Submit a session idea"
+          href="mailto:events@abovethestack.com"
+          cta="Share your proposal"
+          icon={<Lightbulb aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+          iconAccent="sky"
+        >
           We welcome ideas from members and partners. Tell us the challenge you want to unpack, the audience you hope to gather, and what success looks like.
         </Card>
-        <Card title="Partner opportunities" href="mailto:partnerships@abovethestack.com" cta="Discuss collaboration" icon="🤝">
+        <Card
+          title="Partner opportunities"
+          href="mailto:partnerships@abovethestack.com"
+          cta="Discuss collaboration"
+          icon={<Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+          iconAccent="coral"
+        >
           Vendors can co-host educational sessions. We work with you to keep the content practical and bias-free.
         </Card>
       </Section>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,9 +3,34 @@ import Section from '@/components/Section'
 import Card from '@/components/Card'
 import LatestThreads from '@/components/LatestThreads'
 import MemberCard from '@/components/MemberCard'
+import IconBadge from '@/components/IconBadge'
 import { leadershipTeam } from '@/data/leadershipTeam'
+import {
+  BarChart3,
+  BrainCircuit,
+  CalendarClock,
+  Compass,
+  Globe2,
+  Handshake,
+  Library,
+  Lightbulb,
+  MicVocal,
+  Puzzle,
+  Radar,
+  RadioTower,
+  Satellite,
+  SatelliteDish,
+  Search,
+  ShieldCheck,
+  ShieldHalf,
+  Sparkles,
+  UsersRound,
+  Vote,
+} from 'lucide-react'
 
 const defaultPortalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
+
+const iconClass = 'h-5 w-5'
 
 const upcomingHighlights = [
   {
@@ -16,7 +41,8 @@ const upcomingHighlights = [
     href: '/research',
     cta: 'Read the outline',
     className: 'border-transparent bg-gradient-to-br from-white via-atsSky/15 to-atsOcean/10',
-    icon: '📊',
+    iconAccent: 'midnight' as const,
+    icon: <BarChart3 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     eyebrow: 'Playbook',
@@ -25,7 +51,8 @@ const upcomingHighlights = [
       'Implementation workflows, customer comms, and pricing guidance created by operators already living the directive.',
     href: '/playbooks',
     cta: 'See the chapters',
-    icon: '🛡️',
+    iconAccent: 'ocean' as const,
+    icon: <ShieldCheck aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     eyebrow: 'Roundtable',
@@ -35,7 +62,8 @@ const upcomingHighlights = [
     href: '/events',
     cta: 'Reserve your seat',
     className: 'border-transparent bg-gradient-to-br from-white via-atsCoral/20 to-atsSky/10',
-    icon: '🤝',
+    iconAccent: 'coral' as const,
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -43,17 +71,20 @@ const memberDesigned = [
   {
     title: 'Signals shaped by peers',
     description: 'Members vote on the research we publish, share data, and co-author playbooks that are reviewed in the open.',
-    icon: '🗳️',
+    iconAccent: 'midnight' as const,
+    icon: <Vote aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Transparent collaboration',
     description: 'Every conversation happens under real names with context so operators can learn together, not in silos.',
-    icon: '🔍',
+    iconAccent: 'sky' as const,
+    icon: <Search aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Global reach, local nuance',
     description: 'Chapters across EMEA, North America, and APAC compare regulation, pricing pressure, and service design.',
-    icon: '🌍',
+    iconAccent: 'coral' as const,
+    icon: <Globe2 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -61,22 +92,26 @@ const membershipBenefits = [
   {
     title: 'All employees included',
     description: 'One €150/year company membership covers your whole team with local currency equivalents.',
-    icon: '👥',
+    accent: 'ocean' as const,
+    icon: <UsersRound aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
   {
     title: 'Guided onboarding',
     description: 'Meet moderators, get recommendations for lounges, and receive a personal Above Connect orientation.',
-    icon: '🧭',
+    accent: 'sky' as const,
+    icon: <Compass aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
   {
     title: 'Living library',
     description: 'Research, playbooks, and templates are refreshed as the community reports back on what works.',
-    icon: '📚',
+    accent: 'slate' as const,
+    icon: <Library aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
   {
     title: 'Member-led programmes',
     description: 'Roundtables, office hours, and partner workshops run every month — all recorded inside Above Connect.',
-    icon: '🎙️',
+    accent: 'coral' as const,
+    icon: <MicVocal aria-hidden="true" className="h-5 w-5" strokeWidth={1.8} />,
   },
 ]
 
@@ -84,27 +119,32 @@ const whyMsps = [
   {
     title: 'Managed Service Providers (MSPs)',
     description: 'Deliver the ongoing customer experience, run the stack, and keep clients productive. You sit at the heart of every decision we make.',
-    icon: '💡',
+    iconAccent: 'ocean' as const,
+    icon: <Lightbulb aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Managed Security Service Providers (MSSPs)',
     description: 'Bring deep security expertise, compliance stewardship, and incident response knowledge that strengthens the whole community.',
-    icon: '🛡️',
+    iconAccent: 'midnight' as const,
+    icon: <ShieldHalf aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Managed Infrastructure Providers (MIPs)',
     description: 'Operate critical infrastructure, cloud, and connectivity that power digital businesses — your insights shape our playbooks.',
-    icon: '🛰️',
+    iconAccent: 'sky' as const,
+    icon: <SatelliteDish aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Service Providers (SPs)',
     description: 'From telecom to vertical IT specialists, your service delivery models keep customers connected and confident.',
-    icon: '📡',
+    iconAccent: 'slate' as const,
+    icon: <RadioTower aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Consultancies & advisors',
     description: 'Advisors who build managed offerings or guide MSPs on transformation are welcome. Bring your frameworks and learnings.',
-    icon: '🧠',
+    iconAccent: 'coral' as const,
+    icon: <BrainCircuit aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -135,28 +175,32 @@ const programs = [
     description: '12-person rooms moderated by the editorial team to unpack pricing, delivery, and growth bets with peers.',
     href: '/events',
     cta: 'Explore sessions',
-    icon: '🧩',
+    iconAccent: 'midnight' as const,
+    icon: <Puzzle aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Research briefings',
     description: 'Monthly walkthroughs of upcoming reports with the analysts and members who provided the data.',
     href: '/research',
     cta: 'Get notified',
-    icon: '🛰️',
+    iconAccent: 'ocean' as const,
+    icon: <Radar aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Partner workshops',
     description: 'Neutral collaboration spaces where vendors, distributors, and MSPs stress test roadmaps.',
     href: '/community',
     cta: 'Request an invite',
-    icon: '🤝',
+    iconAccent: 'coral' as const,
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Office hours',
     description: 'Weekly clinics with members and moderators to debug tooling, share dashboards, and swap templates.',
     href: `${defaultPortalUrl}/latest`,
     cta: 'See schedule',
-    icon: '🗓️',
+    iconAccent: 'sky' as const,
+    icon: <CalendarClock aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -181,6 +225,7 @@ export default function HomePage() {
             cta={item.cta}
             className={`${item.className ?? ''} shadow-glow`}
             icon={item.icon}
+            iconAccent={item.iconAccent}
           >
             {item.description}
           </Card>
@@ -193,7 +238,12 @@ export default function HomePage() {
         description="Above The Stack is more than a portal — it’s a working studio for MSPs, MSSPs, and partners who believe in building together."
       >
         {memberDesigned.map((feature) => (
-          <Card key={feature.title} title={feature.title} icon={feature.icon}>
+          <Card
+            key={feature.title}
+            title={feature.title}
+            icon={feature.icon}
+            iconAccent={feature.iconAccent}
+          >
             {feature.description}
           </Card>
         ))}
@@ -215,9 +265,9 @@ export default function HomePage() {
             </p>
           </div>
           <div className="space-y-3 text-sm text-slate-600">
-            <div className="flex items-center gap-2 text-atsMidnight">
-              <span className="text-lg" aria-hidden>
-                ✨
+            <div className="flex items-center gap-3 text-atsMidnight">
+              <span className="inline-flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-atsOcean/10 text-atsOcean">
+                <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} />
               </span>
               Your MSP community is waiting inside Above Connect.
             </div>
@@ -237,9 +287,9 @@ export default function HomePage() {
               key={benefit.title}
               className="card flex items-start gap-4 border-white/70 bg-white/90 p-5 text-left shadow-[0_25px_60px_-48px_rgba(15,31,75,0.6)]"
             >
-              <span className="mt-1 text-2xl" aria-hidden>
+              <IconBadge className="mt-1" size="md" variant={benefit.accent}>
                 {benefit.icon}
-              </span>
+              </IconBadge>
               <div className="space-y-1">
                 <h4 className="text-base font-semibold text-atsMidnight">{benefit.title}</h4>
                 <p className="text-sm text-slate-600">{benefit.description}</p>
@@ -294,7 +344,12 @@ export default function HomePage() {
         columns="three"
       >
         {whyMsps.map((item) => (
-          <Card key={item.title} title={item.title} icon={item.icon}>
+          <Card
+            key={item.title}
+            title={item.title}
+            icon={item.icon}
+            iconAccent={item.iconAccent}
+          >
             {item.description}
           </Card>
         ))}
@@ -307,7 +362,14 @@ export default function HomePage() {
         columns="two"
       >
         {programs.map((program) => (
-          <Card key={program.title} title={program.title} href={program.href} cta={program.cta} icon={program.icon}>
+          <Card
+            key={program.title}
+            title={program.title}
+            href={program.href}
+            cta={program.cta}
+            icon={program.icon}
+            iconAccent={program.iconAccent}
+          >
             {program.description}
           </Card>
         ))}

--- a/app/playbooks/page.tsx
+++ b/app/playbooks/page.tsx
@@ -1,25 +1,40 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
+import {
+  Bot,
+  ChartSpline,
+  FileText,
+  Lightbulb,
+  MessagesSquare,
+  PenLine,
+  ScrollText,
+  ToolCase,
+} from 'lucide-react'
 
 export const metadata = { title: 'Playbooks — Above The Stack' }
 
 const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
+const iconClass = 'h-5 w-5'
+
 const playbooks = [
   {
     title: 'NIS2 readiness kit',
     description: 'Gap assessment templates, customer comms, and service packaging guidance to operationalise the directive.',
-    icon: '🧾',
+    iconAccent: 'midnight' as const,
+    icon: <ScrollText aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'AI service launch framework',
     description: 'Positioning, pricing, and delivery runbooks for rolling out AI-enabled support without eroding trust.',
-    icon: '🤖',
+    iconAccent: 'ocean' as const,
+    icon: <Bot aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Customer success dashboard',
     description: 'A full measurement model linking support signals to retention, expansion, and advocacy metrics.',
-    icon: '📊',
+    iconAccent: 'sky' as const,
+    icon: <ChartSpline aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -27,17 +42,20 @@ const whatsInside = [
   {
     title: 'Executive summary',
     description: 'A concise readout distilling the why, the opportunity, and the pitfalls — ready to share with leadership and partners.',
-    icon: '🧠',
+    iconAccent: 'ocean' as const,
+    icon: <FileText aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Implementation toolkit',
     description: 'Templates, checklists, and SOPs to plug directly into your PSA, documentation, and customer success workflows.',
-    icon: '🧰',
+    iconAccent: 'midnight' as const,
+    icon: <ToolCase aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Community feedback loop',
     description: 'Dedicated Above Connect threads to surface questions, share outcomes, and collectively improve the material.',
-    icon: '💬',
+    iconAccent: 'coral' as const,
+    icon: <MessagesSquare aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -66,7 +84,12 @@ export default function Page() {
         description="Members can follow along as we build. Expect worksheets, calculators, facilitation guides, and ready-to-share collateral."
       >
         {playbooks.map((item) => (
-          <Card key={item.title} title={item.title} icon={item.icon}>
+          <Card
+            key={item.title}
+            title={item.title}
+            icon={item.icon}
+            iconAccent={item.iconAccent}
+          >
             {item.description}
           </Card>
         ))}
@@ -74,17 +97,34 @@ export default function Page() {
 
       <Section eyebrow="What’s inside" title="Every playbook ships with">
         {whatsInside.map((item) => (
-          <Card key={item.title} title={item.title} icon={item.icon}>
+          <Card
+            key={item.title}
+            title={item.title}
+            icon={item.icon}
+            iconAccent={item.iconAccent}
+          >
             {item.description}
           </Card>
         ))}
       </Section>
 
       <Section eyebrow="Contribute" title="Help us build the next playbook" columns="two">
-        <Card title="Suggest a topic" href="mailto:hello@abovethestack.com" cta="Submit an idea" icon="💡">
+        <Card
+          title="Suggest a topic"
+          href="mailto:hello@abovethestack.com"
+          cta="Submit an idea"
+          icon={<Lightbulb aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+          iconAccent="sky"
+        >
           Let us know which challenge you want solved next. We co-create outlines with members and invite operators to share their working documents.
         </Card>
-        <Card title="Become a reviewer" href={`${portalUrl}/groups/reviewers`} cta="Join the reviewer group" icon="📝">
+        <Card
+          title="Become a reviewer"
+          href={`${portalUrl}/groups/reviewers`}
+          cta="Join the reviewer group"
+          icon={<PenLine aria-hidden="true" className={iconClass} strokeWidth={1.8} />}
+          iconAccent="midnight"
+        >
           Review drafts ahead of release, contribute examples, and receive shout-outs in the published editions.
         </Card>
       </Section>

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -1,25 +1,41 @@
 import Card from '@/components/Card'
 import Section from '@/components/Section'
+import {
+  BarChart3,
+  ClipboardCheck,
+  Globe2,
+  Handshake,
+  Map,
+  RefreshCcw,
+  ScrollText,
+  ShieldCheck,
+  UsersRound,
+} from 'lucide-react'
 
 export const metadata = { title: 'Research — Above The Stack' }
 
 const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
+const iconClass = 'h-5 w-5'
+
 const pillars = [
   {
     title: 'Market intelligence',
     description: 'Sizing, growth trajectories, and economics behind MSP service lines and partner ecosystems across regions.',
-    icon: '🌐',
+    iconAccent: 'ocean' as const,
+    icon: <Globe2 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Regulation & compliance',
     description: 'Breakdowns of NIS2, DORA, and local regulations paired with implementation implications for MSP teams.',
-    icon: '📜',
+    iconAccent: 'midnight' as const,
+    icon: <ScrollText aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Operating benchmarks',
     description: 'Metrics on delivery efficiency, customer acquisition costs, and tooling adoption to guide investments.',
-    icon: '📈',
+    iconAccent: 'sky' as const,
+    icon: <BarChart3 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -27,17 +43,20 @@ const releases = [
   {
     title: 'Global MSP Landscape 2025',
     description: 'Service mix, profitability signals, and competitive positioning across 120+ MSPs in multiple regions.',
-    icon: '🗺️',
+    iconAccent: 'sky' as const,
+    icon: <Map aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Vendor Relationship Pulse',
     description: 'How MSPs evaluate vendor partners, MDF programmes, and co-selling expectations for the year ahead.',
-    icon: '🤝',
+    iconAccent: 'coral' as const,
+    icon: <Handshake aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'State of Managed Security',
     description: 'Pricing models, staffing, and incident response capabilities for security-centric MSP offerings.',
-    icon: '🛡️',
+    iconAccent: 'midnight' as const,
+    icon: <ShieldCheck aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -45,22 +64,26 @@ const methodology = [
   {
     title: 'Community-led',
     description: 'Surveys and interviews originate from member questions. We vet every data contributor and anonymise results.',
-    icon: '🧭',
+    iconAccent: 'ocean' as const,
+    icon: <UsersRound aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Transparent & iterative',
     description: 'Draft findings are posted in Above Connect for feedback. Members challenge assumptions before publication.',
-    icon: '🔄',
+    iconAccent: 'sky' as const,
+    icon: <RefreshCcw aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Practical outcomes',
     description: 'Each report includes actions, metrics to monitor, and supporting templates so teams can implement fast.',
-    icon: '🛠️',
+    iconAccent: 'coral' as const,
+    icon: <ClipboardCheck aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
     title: 'Global relevance',
     description: 'We compare insights with MSPs worldwide to highlight regional differences and transferable learnings.',
-    icon: '🌍',
+    iconAccent: 'slate' as const,
+    icon: <Globe2 aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
 ]
 
@@ -85,7 +108,12 @@ export default function Page() {
 
       <Section eyebrow="Focus areas" title="What we analyse">
         {pillars.map((pillar) => (
-          <Card key={pillar.title} title={pillar.title} icon={pillar.icon}>
+          <Card
+            key={pillar.title}
+            title={pillar.title}
+            icon={pillar.icon}
+            iconAccent={pillar.iconAccent}
+          >
             {pillar.description}
           </Card>
         ))}
@@ -97,7 +125,12 @@ export default function Page() {
         description="Members can review chapters before they ship, influence what we measure, and join live read-outs."
       >
         {releases.map((release) => (
-          <Card key={release.title} title={release.title} icon={release.icon}>
+          <Card
+            key={release.title}
+            title={release.title}
+            icon={release.icon}
+            iconAccent={release.iconAccent}
+          >
             {release.description}
           </Card>
         ))}
@@ -105,7 +138,12 @@ export default function Page() {
 
       <Section eyebrow="Methodology" title="How we produce our research" columns="two">
         {methodology.map((item) => (
-          <Card key={item.title} title={item.title} icon={item.icon}>
+          <Card
+            key={item.title}
+            title={item.title}
+            icon={item.icon}
+            iconAccent={item.iconAccent}
+          >
             {item.description}
           </Card>
         ))}

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link'
 import type { ReactNode } from 'react'
+import IconBadge, { type IconBadgeVariant } from './IconBadge'
 
 type CardProps = {
   title: string
@@ -9,9 +10,19 @@ type CardProps = {
   cta?: string
   className?: string
   icon?: ReactNode
+  iconAccent?: IconBadgeVariant
 }
 
-export default function Card({ title, href, children, eyebrow, cta, className, icon }: CardProps) {
+export default function Card({
+  title,
+  href,
+  children,
+  eyebrow,
+  cta,
+  className,
+  icon,
+  iconAccent,
+}: CardProps) {
   const baseClasses = ['card', 'h-full', 'group', className].filter(Boolean).join(' ')
 
   const iconMarkup =
@@ -24,9 +35,7 @@ export default function Card({ title, href, children, eyebrow, cta, className, i
   const content = (
     <div className="space-y-4">
       {icon && (
-        <div className="relative inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-atsSky/15 via-white to-atsOcean/15 text-atsMidnight shadow-[0_12px_30px_-18px_rgba(15,31,75,0.45)]">
-          {iconMarkup}
-        </div>
+        <IconBadge variant={iconAccent}>{iconMarkup}</IconBadge>
       )}
       {eyebrow && <span className="eyebrow text-[0.65rem] text-atsOcean/60">{eyebrow}</span>}
       <h3 className="text-lg font-semibold text-atsMidnight md:text-xl">{title}</h3>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Sparkles } from 'lucide-react'
 import { communityCommitments } from '@/data/community'
 
 const heroStats = [
@@ -20,7 +21,7 @@ export default function Hero() {
         <div className="space-y-10 text-left">
           <div className="space-y-5">
             <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80 shadow-inner">
-              <span aria-hidden>👋</span> Welcome to Above The Stack
+              <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Welcome to Above The Stack
             </span>
             <h1 className="h1 text-balance text-atsMidnight">
               Your MSP community is waiting

--- a/components/IconBadge.tsx
+++ b/components/IconBadge.tsx
@@ -1,0 +1,41 @@
+import type { ReactNode } from 'react'
+
+export type IconBadgeVariant = 'ocean' | 'sky' | 'coral' | 'midnight' | 'slate'
+
+const variantStyles: Record<IconBadgeVariant, string> = {
+  ocean: 'from-atsSky/25 via-white to-atsOcean/30 text-atsMidnight',
+  sky: 'from-white via-atsSky/30 to-atsOcean/15 text-atsMidnight',
+  coral: 'from-atsCoral/25 via-white to-atsSky/20 text-atsMidnight',
+  midnight: 'from-atsMidnight via-atsMidnight/80 to-atsOcean/60 text-white',
+  slate: 'from-slate-100 via-white to-slate-200 text-atsMidnight',
+}
+
+const sizeStyles = {
+  lg: 'h-12 w-12 rounded-2xl text-base',
+  md: 'h-10 w-10 rounded-xl text-sm',
+}
+
+type IconBadgeProps = {
+  children: ReactNode
+  variant?: IconBadgeVariant
+  size?: keyof typeof sizeStyles
+  className?: string
+}
+
+export default function IconBadge({
+  children,
+  variant = 'ocean',
+  size = 'lg',
+  className,
+}: IconBadgeProps) {
+  const classes = [
+    'inline-flex items-center justify-center bg-gradient-to-br shadow-[0_18px_40px_-32px_rgba(15,31,75,0.55)] ring-1 ring-inset ring-white/60',
+    variantStyles[variant],
+    sizeStyles[size],
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ')
+
+  return <span className={classes}>{children}</span>
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "above-the-stack",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^0.544.0",
         "next": "14.2.11",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -3922,6 +3923,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.544.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.544.0.tgz",
+      "integrity": "sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "lucide-react": "^0.544.0",
     "next": "14.2.11",
     "react": "18.3.1",
     "react-dom": "18.3.1",


### PR DESCRIPTION
## Summary
- add an IconBadge component and update Card to support accent variants so icons render inside consistent gradient badges
- restyle the home page membership section and feature highlights with the new icon badges and curated accent colors
- align the about, community, events, playbooks, and research pages with the refreshed icon system for visual consistency

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d099ac9d4883278274e941e15cbae1