### PR TITLE
Fix playbooks icon reference and update leadership headshots

### DIFF
--- a/app/playbooks/page.tsx
+++ b/app/playbooks/page.tsx
@@ -51,11 +51,6 @@ const whatsInside = [
     iconAccent: 'midnight' as const,
     icon: <ToolCase aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
-{
-  title: 'Implementation toolkit',
-  description: 'Templates, checklists, and SOPs to plug directly into your PSA, documentation, and customer success workflows.',
-  icon: <Toolbox aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
-},
   {
     title: 'Community feedback loop',
     description: 'Dedicated Above Connect threads to surface questions, share outcomes, and collectively improve the material.',

--- a/data/leadershipTeam.ts
+++ b/data/leadershipTeam.ts
@@ -7,27 +7,6 @@ export type LeadershipMember = {
   headshot?: string
 }
 
-const createMonogramHeadshot = (initials: string, gradient: [string, string]) => {
-  const sanitizedInitials = initials.replace(/\s+/g, '')
-  const gradientId = `grad-${sanitizedInitials.toLowerCase()}`
-  const svg = [
-    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">',
-    '<defs>',
-    `<linearGradient id="${gradientId}" x1="0%" y1="0%" x2="100%" y2="100%">`,
-    `<stop offset="0%" stop-color="${gradient[0]}"/>`,
-    `<stop offset="100%" stop-color="${gradient[1]}"/>`,
-    '</linearGradient>',
-    '</defs>',
-    `<rect width="128" height="128" rx="28" fill="url(#${gradientId})"/>`,
-    "<text x='50%' y='50%' dominant-baseline='central' text-anchor='middle' font-family='\\'Inter\\', \\'Segoe UI\\', sans-serif' font-size='52' font-weight='600' fill='#F8FAFC' letter-spacing='2'>",
-    sanitizedInitials,
-    '</text>',
-    '</svg>',
-  ].join('')
-
-  return `data:image/svg+xml,${encodeURIComponent(svg)}`
-}
-
 export const leadershipTeam: LeadershipMember[] = [
   {
     name: 'Tycho Löke',
@@ -35,7 +14,7 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Benelux, Nordics, Baltics)',
     bio: 'Tycho has spent eight years immersed in the MSP ecosystem. After leading enablement on the provider side, he now works with platform providers and MSPs to support go-to-market execution and service design without losing sight of the operator perspective. He is a committed knowledge sharer and evangelist for MSP success worldwide.',
     quote: 'We built Above The Stack so operators can compare notes without the vendor noise crowding other rooms.',
-    headshot: createMonogramHeadshot('TL', ['#0EA5E9', '#1D4ED8']),
+    headshot: 'https://www.linkedin.com/in/tycholoke/overlay/photo/',
   },
   {
     name: 'Ashley Schut',
@@ -43,7 +22,7 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Benelux)',
     bio: 'Ashley brings eight years of experience supporting the channel, including seven years at ESET before joining Arctic Wolf. She lives and breathes cybersecurity while championing vendor-neutral spaces where MSPs can thrive.',
     quote: 'Community works when security and trust lead every discussion — that is the heartbeat of Above The Stack.',
-    headshot: createMonogramHeadshot('AS', ['#F97316', '#C2410C']),
+    headshot: 'https://www.linkedin.com/in/ashley-schut-a1aa06105/overlay/photo/',
   },
   {
     name: 'Timon Bergsma',
@@ -51,7 +30,7 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Benelux and France)',
     bio: 'Timon is a true enabler who knows how to connect MSPs and partners around the right opportunities without turning the dialogue into a pitch. His people-first approach helps build collaborations that unlock the best in every team, making him a natural leader in community spaces.',
     quote: 'MSPs grow faster when we create space to be honest, generous, and a little bit human together.',
-    headshot: createMonogramHeadshot('TB', ['#10B981', '#047857']),
+    headshot: 'https://www.linkedin.com/in/cloud-enthousiast/overlay/photo/',
   },
   {
     name: 'Pierre Kleine-Schaars',
@@ -59,6 +38,6 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Netherlands)',
     bio: 'Pierre is a veteran of the channel with a track record of launching successful businesses and ideas. Today he brings deep expertise across AI, automation, and cybersecurity to help the community push the industry forward with a truly global mindset.',
     quote: 'The future of the channel is transparent, data-driven, and global — exactly how we steward Above The Stack.',
-    headshot: createMonogramHeadshot('PK', ['#A855F7', '#6D28D9']),
+    headshot: 'https://www.linkedin.com/in/qaasspecialist/overlay/photo/',
   },
 ]


### PR DESCRIPTION
## Summary
- remove the stray duplicate card on the playbooks page and ensure the implementation toolkit uses the existing ToolCase icon
- replace the autogenerated leadership team monograms with the requested LinkedIn profile photos

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d0a2edd4048327937addd6630f6de3