### PR TITLE
Refresh leadership headshots and icon spacing

### DIFF
--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -99,9 +99,9 @@ export default function Page() {
           </p>
           <ul className="space-y-4 text-sm leading-relaxed">
             {highlights.map((item) => (
-              <li key={item.title} className="flex items-start gap-4">
+              <li key={item.title} className="flex items-start gap-5">
                 <span className="mt-1 h-2.5 w-2.5 flex-shrink-0 rounded-full bg-gradient-to-br from-atsSky via-atsOcean to-atsCoral shadow-[0_4px_12px_rgba(19,42,93,0.35)]" />
-                <div className="space-y-1">
+                <div className="space-y-2">
                   <h3 className="text-base font-semibold text-atsMidnight">{item.title}</h3>
                   <p className="text-slate-600">{item.description}</p>
                 </div>
@@ -133,13 +133,13 @@ export default function Page() {
             </div>
             <ul className="space-y-4 text-sm leading-relaxed text-slate-600">
               {communityCommitments.map((item) => (
-                <li key={item.title} className="flex items-start gap-4">
+                <li key={item.title} className="flex items-start gap-5">
                   <span
-                    className={`mt-1 inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br ${item.gradient} text-[0.65rem] font-semibold uppercase tracking-wide text-white shadow-glow`}
+                    className={`mt-1 inline-flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br ${item.gradient} text-[0.65rem] font-semibold uppercase tracking-wide text-white shadow-glow`}
                   >
                     {item.label}
                   </span>
-                  <div className="space-y-1">
+                  <div className="space-y-2">
                     <h3 className="text-sm font-semibold text-atsMidnight">{item.title}</h3>
                     <p>{item.description}</p>
                   </div>
@@ -186,7 +186,7 @@ export default function Page() {
           <h3 className="text-lg font-semibold text-atsMidnight">What to expect</h3>
           <ul className="space-y-3 text-sm leading-relaxed text-slate-600">
             {expectations.map((item) => (
-              <li key={item} className="flex items-start gap-3">
+              <li key={item} className="flex items-start gap-4">
                 <span className="mt-1 h-2 w-2 rounded-full bg-atsOcean" />
                 {item}
               </li>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 href="/"
                 className="flex items-center gap-3 text-lg font-semibold tracking-tight text-atsMidnight transition hover:text-atsOcean"
               >
-                <span className="inline-flex h-11 w-11 items-center justify-center rounded-[1rem] bg-gradient-to-br from-atsSky via-atsOcean to-atsCoral text-base font-bold text-white shadow-glow">
+                <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-gradient-to-br from-atsSky via-atsOcean to-atsCoral text-base font-bold text-white shadow-glow">
                   ATS
                 </span>
                 <span className="hidden sm:inline">Above The Stack</span>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -129,8 +129,8 @@ const whyMsps = [
     icon: <ShieldHalf aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
   {
-    title: 'Managed Infrastructure Providers (MIPs)',
-    description: 'Operate critical infrastructure, cloud, and connectivity that power digital businesses — your insights shape our playbooks.',
+    title: 'Managed Intelligence Providers (MIPs)',
+    description: 'AI-centric MSPs weaving automation and intelligence into service delivery — your experiments accelerate every playbook we produce.',
     iconAccent: 'sky' as const,
     icon: <SatelliteDish aria-hidden="true" className={iconClass} strokeWidth={1.8} />,
   },
@@ -285,13 +285,13 @@ export default function HomePage() {
           {membershipBenefits.map((benefit) => (
             <div
               key={benefit.title}
-              className="card flex items-start gap-4 border-white/70 bg-white/90 p-5 text-left shadow-[0_25px_60px_-48px_rgba(15,31,75,0.6)]"
+              className="card flex items-start gap-5 border-white/70 bg-white/90 p-5 text-left shadow-[0_25px_60px_-48px_rgba(15,31,75,0.6)]"
             >
 
-              <IconBadge className="mt-1" size="md" variant={benefit.accent}>
+              <IconBadge className="mt-0.5" size="md" variant={benefit.accent}>
                 {benefit.icon}
               </IconBadge>
-              <div className="space-y-1">
+              <div className="space-y-2">
                 <h4 className="text-base font-semibold text-atsMidnight">{benefit.title}</h4>
                 <p className="text-sm text-slate-600">{benefit.description}</p>
               </div>

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -33,7 +33,7 @@ export default function Card({
     )
 
   const content = (
-    <div className="space-y-4">
+    <div className="space-y-5">
       {icon && (
         <IconBadge variant={iconAccent}>{iconMarkup}</IconBadge>
       )}

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -73,13 +73,13 @@ export default function Hero() {
                 <div
                   className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${item.gradient} opacity-10 transition-opacity duration-300 group-hover:opacity-25`}
                 />
-                <div className="relative flex items-center gap-4">
+                <div className="relative flex items-center gap-5">
                   <span
-                    className={`inline-flex h-11 w-11 flex-shrink-0 items-center justify-center rounded-2xl bg-gradient-to-br ${item.gradient} text-xs font-semibold uppercase tracking-[0.25em] text-white shadow-glow`}
+                    className={`inline-flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br ${item.gradient} text-xs font-semibold uppercase tracking-[0.25em] text-white shadow-glow`}
                   >
                     {item.label}
                   </span>
-                  <div className="space-y-1">
+                  <div className="space-y-2">
                     <h3 className="text-sm font-semibold text-atsMidnight">{item.title}</h3>
                     <p className="text-sm text-slate-600">{item.description}</p>
                   </div>

--- a/components/IconBadge.tsx
+++ b/components/IconBadge.tsx
@@ -11,8 +11,8 @@ const variantStyles: Record<IconBadgeVariant, string> = {
 }
 
 const sizeStyles = {
-  lg: 'h-12 w-12 rounded-2xl text-base',
-  md: 'h-10 w-10 rounded-xl text-sm',
+  lg: 'h-14 w-14 rounded-full text-base',
+  md: 'h-12 w-12 rounded-full text-sm',
 }
 
 type IconBadgeProps = {
@@ -29,7 +29,7 @@ export default function IconBadge({
   className,
 }: IconBadgeProps) {
   const classes = [
-    'inline-flex items-center justify-center bg-gradient-to-br shadow-[0_18px_40px_-32px_rgba(15,31,75,0.55)] ring-1 ring-inset ring-white/60',
+    'inline-flex flex-shrink-0 items-center justify-center bg-gradient-to-br shadow-[0_18px_40px_-32px_rgba(15,31,75,0.55)] ring-1 ring-inset ring-white/60',
     variantStyles[variant],
     sizeStyles[size],
     className,

--- a/components/MemberCard.tsx
+++ b/components/MemberCard.tsx
@@ -11,9 +11,9 @@ export default function MemberCard({ member }: MemberCardProps) {
   const isDataUriHeadshot = Boolean(headshotSrc?.startsWith('data:image/'))
 
   return (
-    <article className="card h-full space-y-5 p-7">
-      <div className="flex items-center gap-4">
-        <div className="relative h-20 w-20 overflow-hidden rounded-3xl bg-atsOcean/10 ring-1 ring-atsOcean/15">
+    <article className="card h-full space-y-6 p-7">
+      <div className="flex items-center gap-5">
+        <div className="relative h-20 w-20 overflow-hidden rounded-full bg-atsOcean/10 ring-1 ring-atsOcean/15">
           {hasHeadshot && headshotSrc ? (
             <Image
               src={headshotSrc}
@@ -29,7 +29,7 @@ export default function MemberCard({ member }: MemberCardProps) {
             </span>
           )}
         </div>
-        <div className="space-y-1">
+        <div className="space-y-2">
           <h3 className="text-lg font-semibold text-atsMidnight">{member.name}</h3>
           <p className="text-sm font-medium text-atsOcean">{member.role}</p>
           <p className="text-xs uppercase tracking-[0.2em] text-atsOcean/60">{member.region}</p>

--- a/data/leadershipTeam.ts
+++ b/data/leadershipTeam.ts
@@ -14,7 +14,8 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Benelux, Nordics, Baltics)',
     bio: 'Tycho has spent eight years immersed in the MSP ecosystem. After leading enablement on the provider side, he now works with platform providers and MSPs to support go-to-market execution and service design without losing sight of the operator perspective. He is a committed knowledge sharer and evangelist for MSP success worldwide.',
     quote: 'We built Above The Stack so operators can compare notes without the vendor noise crowding other rooms.',
-    headshot: 'https://www.linkedin.com/in/tycholoke/overlay/photo/',
+    headshot:
+      'https://media.licdn.com/dms/image/v2/D4E03AQHTJ_l28d5zhQ/profile-displayphoto-scale_400_400/B4EZhys6.tGcAk-/0/1754271039021?e=1761177600&v=beta&t=cUXfkXy1TOTm459JhsLY-P3qvRkYux_i_9COLZitkTY',
   },
   {
     name: 'Ashley Schut',
@@ -22,7 +23,8 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Benelux)',
     bio: 'Ashley brings eight years of experience supporting the channel, including seven years at ESET before joining Arctic Wolf. She lives and breathes cybersecurity while championing vendor-neutral spaces where MSPs can thrive.',
     quote: 'Community works when security and trust lead every discussion — that is the heartbeat of Above The Stack.',
-    headshot: 'https://www.linkedin.com/in/ashley-schut-a1aa06105/overlay/photo/',
+    headshot:
+      'https://media.licdn.com/dms/image/v2/C4E03AQHcOE0oTcwitw/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1636616489887?e=1761177600&v=beta&t=eV8USaAgmi4nYNmpExet8ntVmWH7Kx2WcSc0jTDxS74',
   },
   {
     name: 'Timon Bergsma',
@@ -30,7 +32,8 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Benelux and France)',
     bio: 'Timon is a true enabler who knows how to connect MSPs and partners around the right opportunities without turning the dialogue into a pitch. His people-first approach helps build collaborations that unlock the best in every team, making him a natural leader in community spaces.',
     quote: 'MSPs grow faster when we create space to be honest, generous, and a little bit human together.',
-    headshot: 'https://www.linkedin.com/in/cloud-enthousiast/overlay/photo/',
+    headshot:
+      'https://media.licdn.com/dms/image/v2/D4E03AQHXn54kWzVsqA/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1693304272129?e=1761177600&v=beta&t=7a8RjubVApiqD73RVarZefNHU-J-UGaa0Z-WmRGR_b0',
   },
   {
     name: 'Pierre Kleine-Schaars',
@@ -38,6 +41,7 @@ export const leadershipTeam: LeadershipMember[] = [
     region: 'Global programs (based in Netherlands)',
     bio: 'Pierre is a veteran of the channel with a track record of launching successful businesses and ideas. Today he brings deep expertise across AI, automation, and cybersecurity to help the community push the industry forward with a truly global mindset.',
     quote: 'The future of the channel is transparent, data-driven, and global — exactly how we steward Above The Stack.',
-    headshot: 'https://www.linkedin.com/in/qaasspecialist/overlay/photo/',
+    headshot:
+      'https://media.licdn.com/dms/image/v2/D4E03AQEaw5AXj2yn6Q/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1719233183766?e=1761177600&v=beta&t=9QBOTwlrwIgBTJXdS7BaV6A8v_CnSt6c0FcD5QMCH3Y',
   },
 ]


### PR DESCRIPTION
## Summary
- ensure icon badges render as full circles and add breathing room around icon/text pairings across hero, membership, and community sections
- update the navigation mark and member cards so circular imagery displays correctly and leadership spacing feels balanced
- refresh the Managed Intelligence Provider copy and swap in the latest leadership headshots provided by the team

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0a534be5c832783c39d66b027632e