### PR TITLE
Adjust leadership headshot framing

### DIFF
--- a/components/MemberCard.tsx
+++ b/components/MemberCard.tsx
@@ -14,15 +14,15 @@ export default function MemberCard({ member }: MemberCardProps) {
     <article className="card h-full overflow-hidden">
       <div className="flex h-full flex-col gap-8 rounded-[2.25rem] bg-gradient-to-br from-atsOcean/5 via-white to-atsSky/5 px-8 py-9">
         <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
-          <div className="relative h-24 w-24 rounded-3xl bg-gradient-to-br from-atsOcean/40 via-atsSky/25 to-atsCoral/30 p-[3px] shadow-[0_18px_32px_-18px_rgba(15,31,75,0.45)]">
-            <div className="relative h-full w-full overflow-hidden rounded-[1.4rem] bg-white/80">
+          <div className="relative aspect-square w-24 shrink-0 rounded-[1.85rem] bg-gradient-to-br from-atsOcean/40 via-atsSky/25 to-atsCoral/30 p-[3px] shadow-[0_18px_32px_-18px_rgba(15,31,75,0.45)] sm:w-28">
+            <div className="relative h-full w-full overflow-hidden rounded-[1.4rem] bg-white/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)]">
               {hasHeadshot && headshotSrc ? (
                 <Image
                   src={headshotSrc}
                   alt={`${member.name} headshot`}
                   fill
-                  sizes="96px"
-                  className="object-cover"
+                  sizes="(max-width: 640px) 96px, 112px"
+                  className="object-cover object-center"
                   unoptimized={isDataUriHeadshot}
                 />
               ) : (
@@ -38,7 +38,7 @@ export default function MemberCard({ member }: MemberCardProps) {
             <p className="text-base font-medium text-atsOcean">{member.role}</p>
           </div>
         </div>
-        <blockquote className="relative rounded-3xl border border-atsOcean/10 bg-gradient-to-br from-white/90 via-atsOcean/10 to-atsSky/10 px-6 py-5 text-sm font-medium text-atsMidnight/90">
+        <blockquote className="relative rounded-[1.85rem] border border-atsOcean/10 bg-gradient-to-br from-white/90 via-atsOcean/10 to-atsSky/10 px-6 py-5 text-sm font-medium text-atsMidnight/90 shadow-[0_16px_40px_-30px_rgba(15,31,75,0.45)]">
           <span className="absolute left-5 top-3 text-3xl text-atsOcean/30" aria-hidden>
             “
           </span>


### PR DESCRIPTION
## Summary
- enforce a square headshot frame on leadership cards so images keep their intended rounded profile
- refresh the quote panel styling to better align with the existing gradient card treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0aa4a4f508327b9fed840e23d5eed