### PR TITLE
Improve mobile responsiveness

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -63,7 +63,7 @@ export default function Page() {
 
   return (
     <div className="space-y-24">
-      <section className="glass-panel mx-auto max-w-5xl space-y-6 px-10 py-14 text-lg leading-relaxed text-slate-700">
+      <section className="glass-panel mx-auto max-w-5xl space-y-6 px-6 py-12 text-lg leading-relaxed text-slate-700 sm:px-10 sm:py-14">
         <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80">
           <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Our mission
         </span>
@@ -85,11 +85,11 @@ export default function Page() {
         <p className="text-base">
           We officially launch on November 1st with our first in-person meetup in December. Join now to help shape the launch cohort and the programmes that follow.
         </p>
-        <div className="flex flex-wrap gap-3 pt-2">
-          <a className="btn-primary" href={`${portalUrl}/signup`}>
+        <div className="flex flex-col gap-3 pt-2 sm:flex-row sm:flex-wrap">
+          <a className="btn-primary w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
             Become a Member
           </a>
-          <a className="btn-secondary" href="mailto:hello@abovethestack.com">
+          <a className="btn-secondary w-full justify-center sm:w-auto" href="mailto:hello@abovethestack.com">
             Talk to the team
           </a>
         </div>

--- a/app/community/page.tsx
+++ b/app/community/page.tsx
@@ -88,7 +88,7 @@ const steps = [
 export default function Page() {
   return (
     <div className="space-y-24">
-      <section className="relative grid gap-12 rounded-[2.5rem] border border-white/70 bg-white/80 p-10 shadow-[0_32px_70px_-35px_rgba(15,31,75,0.55)] backdrop-blur-xl lg:grid-cols-[1.2fr_1fr]">
+      <section className="relative grid gap-10 rounded-[2.5rem] border border-white/70 bg-white/80 p-6 shadow-[0_32px_70px_-35px_rgba(15,31,75,0.55)] backdrop-blur-xl sm:p-10 lg:grid-cols-[1.2fr_1fr] lg:gap-12">
         <div className="space-y-6 text-slate-700">
           <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80">
             <Sparkles aria-hidden="true" className="h-4 w-4" strokeWidth={1.8} /> Above Connect
@@ -108,22 +108,22 @@ export default function Page() {
               </li>
             ))}
           </ul>
-          <div className="flex flex-wrap gap-3">
-            <a className="btn-primary" href={`${portalUrl}/signup`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <a className="btn-primary w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
               Become a Member
             </a>
-            <a className="btn-secondary" href="mailto:partnerships@abovethestack.com">
+            <a className="btn-secondary w-full justify-center sm:w-auto" href="mailto:partnerships@abovethestack.com">
               Request an Invite
             </a>
-            <a className="btn-secondary" href={portalUrl}>
+            <a className="btn-secondary w-full justify-center sm:w-auto" href={portalUrl}>
               Log in to Above Connect
             </a>
-            <a className="btn-secondary" href="mailto:community@abovethestack.com">
+            <a className="btn-secondary w-full justify-center sm:w-auto" href="mailto:community@abovethestack.com">
               Talk to a moderator
             </a>
           </div>
         </div>
-        <div className="card gradient-border flex h-full flex-col justify-between space-y-6 bg-white/85 p-7">
+        <div className="card gradient-border flex h-full flex-col justify-between space-y-6 bg-white/85 p-6 sm:p-7">
           <div className="space-y-6">
             <div className="flex items-center justify-between gap-3">
               <h2 className="text-xl font-semibold text-atsMidnight">Community commitments</h2>
@@ -176,7 +176,7 @@ export default function Page() {
         description="Log in to Above Connect to view the full threads, join the debate, and access shared files."
         columns="two"
         action={
-          <a className="btn-secondary" href={`${portalUrl}/latest`}>
+          <a className="btn-secondary w-full justify-center sm:w-auto" href={`${portalUrl}/latest`}>
             View all topics
           </a>
         }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -8,7 +8,7 @@ const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethe
 export default function Page() {
   return (
     <div className="space-y-24">
-      <section className="relative overflow-hidden rounded-[3rem] border border-white/70 bg-gradient-to-br from-atsSky/30 via-white to-atsOcean/20 px-10 py-16 shadow-[0_50px_120px_-80px_rgba(15,31,75,0.65)]">
+      <section className="relative overflow-hidden rounded-[2.5rem] border border-white/70 bg-gradient-to-br from-atsSky/30 via-white to-atsOcean/20 px-6 py-12 shadow-[0_50px_120px_-80px_rgba(15,31,75,0.65)] sm:rounded-[3rem] sm:px-10 sm:py-16">
         <div className="absolute -left-32 top-12 h-72 w-72 rounded-full bg-atsOcean/25 blur-3xl" aria-hidden />
         <div className="absolute -right-24 bottom-0 h-60 w-60 rounded-full bg-atsCoral/20 blur-3xl" aria-hidden />
         <div className="relative space-y-6 text-slate-700">
@@ -17,11 +17,11 @@ export default function Page() {
           <p className="max-w-2xl text-lg leading-relaxed">
             Share the challenge you’re solving, the research you’d like to influence, or the playbook you want to see. We read every message and route it to the right people on the leadership team.
           </p>
-          <div className="flex flex-wrap gap-4 pt-2 text-sm text-atsMidnight/80">
-            <a className="btn-secondary" href={portalUrl}>
+          <div className="flex flex-col gap-3 pt-2 text-sm text-atsMidnight/80 sm:flex-row sm:flex-wrap">
+            <a className="btn-secondary w-full justify-center sm:w-auto" href={portalUrl}>
               Log in to Above Connect
             </a>
-            <a className="btn-ghost" href="mailto:hello@abovethestack.com">
+            <a className="btn-ghost w-full justify-center sm:w-auto" href="mailto:hello@abovethestack.com">
               Email hello@abovethestack.com
             </a>
           </div>

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -53,17 +53,17 @@ const formats = [
 export default function Page() {
   return (
     <div className="space-y-24">
-      <section className="glass-panel space-y-6 px-10 py-14 text-lg leading-relaxed text-slate-700">
+      <section className="glass-panel space-y-6 px-6 py-12 text-lg leading-relaxed text-slate-700 sm:px-10 sm:py-14">
         <span className="tag">Programs</span>
         <h1 className="h1 text-balance text-atsMidnight">Events, briefings, and working sessions for builders</h1>
         <p>
           Above The Stack events are intentionally small. We curate the room so every participant can contribute, pressure test ideas, and leave with something immediately usable. Recordings and notes live inside the community for members who cannot attend live.
         </p>
-        <div className="flex flex-wrap gap-3">
-          <a className="btn-primary" href={`${portalUrl}/latest`}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <a className="btn-primary w-full justify-center sm:w-auto" href={`${portalUrl}/latest`}>
             View schedule in Above Connect
           </a>
-          <a className="btn-secondary" href="mailto:events@abovethestack.com">
+          <a className="btn-secondary w-full justify-center sm:w-auto" href="mailto:events@abovethestack.com">
             Suggest a topic
           </a>
         </div>

--- a/app/events/pricing-2025/page.tsx
+++ b/app/events/pricing-2025/page.tsx
@@ -10,12 +10,12 @@ export default function Page() {
       <p>
         Join the newsletter or community to be the first to know when seats become available.
       </p>
-      <div className="flex flex-wrap gap-3">
-        <a className="btn-primary" href="/newsletter">
+      <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+        <a className="btn-primary w-full justify-center sm:w-auto" href="/newsletter">
           Get event alerts
         </a>
         <a
-          className="btn-ghost"
+          className="btn-ghost w-full justify-center sm:w-auto"
           href={process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'}
         >
           Discuss with peers

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,7 +17,7 @@ body {
 }
 
 .container {
-  @apply mx-auto max-w-7xl px-6 md:px-10;
+  @apply mx-auto max-w-7xl px-4 sm:px-6 md:px-10;
 }
 
 .btn {
@@ -43,7 +43,7 @@ body {
 }
 
 .card {
-  @apply relative overflow-hidden rounded-3xl border border-white/80 bg-white/80 p-6 shadow-[0_40px_90px_-45px_rgba(15,31,75,0.55)] backdrop-blur-lg transition duration-300;
+  @apply relative overflow-hidden rounded-3xl border border-white/80 bg-white/80 p-5 shadow-[0_40px_90px_-45px_rgba(15,31,75,0.55)] backdrop-blur-lg transition duration-300 sm:p-6;
 }
 
 .card::before {

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -142,7 +142,7 @@ const collaboration = [
 export default function Page() {
   return (
     <div className="space-y-28">
-      <section className="relative overflow-hidden rounded-[3rem] border border-white/60 bg-gradient-to-br from-atsMidnight via-atsOcean to-atsCoral/80 px-10 py-16 text-white shadow-[0_60px_140px_-80px_rgba(15,31,75,0.85)]">
+      <section className="relative overflow-hidden rounded-[2.5rem] border border-white/60 bg-gradient-to-br from-atsMidnight via-atsOcean to-atsCoral/80 px-6 py-12 text-white shadow-[0_60px_140px_-80px_rgba(15,31,75,0.85)] sm:rounded-[3rem] sm:px-10 sm:py-16">
         <div className="absolute -left-24 top-10 h-64 w-64 rounded-full bg-atsSky/30 blur-3xl" aria-hidden />
         <div className="absolute -bottom-20 right-0 h-72 w-72 rounded-full bg-atsCoral/30 blur-3xl" aria-hidden />
         <div className="relative space-y-8">
@@ -155,11 +155,11 @@ export default function Page() {
           <p className="max-w-2xl text-lg leading-relaxed text-white/80">
             Every release pairs independent market intelligence with practical runbooks. Review early drafts, shape the metrics we track, and ship initiatives with the confidence of a global MSP collective behind you.
           </p>
-          <div className="flex flex-wrap gap-4">
-            <a className="btn-primary bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20" href={`${portalUrl}/c/research/5`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+            <a className="btn-primary w-full justify-center bg-white/10 px-6 py-3 text-sm font-semibold text-white hover:bg-white/20 sm:w-auto" href={`${portalUrl}/c/research/5`}>
               Explore in Above Connect
             </a>
-            <a className="btn-secondary border-white/30 bg-white/10 text-white hover:border-white/50 hover:bg-white/20" href="mailto:research@abovethestack.com">
+            <a className="btn-secondary w-full justify-center border-white/30 bg-white/10 text-white hover:border-white/50 hover:bg-white/20 sm:w-auto" href="mailto:research@abovethestack.com">
               Pitch a collaboration
             </a>
           </div>
@@ -184,7 +184,7 @@ export default function Page() {
         eyebrow="Research programmes"
         title="Market intelligence shaped with operators"
         description="We investigate the topics MSP leaders vote on, combining surveys, interviews, and curated datasets."
-        className="relative overflow-hidden rounded-[2.5rem] border border-atsOcean/15 bg-gradient-to-br from-white/95 via-atsSky/10 to-transparent px-10 py-14"
+        className="relative overflow-hidden rounded-[2rem] border border-atsOcean/15 bg-gradient-to-br from-white/95 via-atsSky/10 to-transparent px-6 py-10 sm:rounded-[2.5rem] sm:px-10 sm:py-14"
       >
         {researchStreams.map((pillar) => (
           <Card
@@ -203,7 +203,7 @@ export default function Page() {
         eyebrow="In development"
         title="Upcoming releases members are already reviewing"
         description="Join feedback sessions, add your data, and access chapter previews before reports go live."
-        className="relative overflow-hidden rounded-[2.5rem] border border-atsOcean/10 bg-gradient-to-br from-white to-atsOcean/5 px-10 py-14"
+        className="relative overflow-hidden rounded-[2rem] border border-atsOcean/10 bg-gradient-to-br from-white to-atsOcean/5 px-6 py-10 sm:rounded-[2.5rem] sm:px-10 sm:py-14"
       >
         {researchPipeline.map((release) => (
           <Card
@@ -222,7 +222,7 @@ export default function Page() {
         eyebrow="Playbook sprints"
         title="Frameworks that translate insights into outcomes"
         description="Every sprint turns research into action with structured experiments, enablement assets, and reporting guidance."
-        className="relative overflow-hidden rounded-[2.5rem] border border-atsCoral/20 bg-gradient-to-br from-white via-atsCoral/10 to-transparent px-10 py-14"
+        className="relative overflow-hidden rounded-[2rem] border border-atsCoral/20 bg-gradient-to-br from-white via-atsCoral/10 to-transparent px-6 py-10 sm:rounded-[2.5rem] sm:px-10 sm:py-14"
       >
         {playbookTracks.map((item) => (
           <Card
@@ -241,7 +241,7 @@ export default function Page() {
         eyebrow="What you receive"
         title="Inside every release"
         description="Browse the library or request a walkthrough. We tailor implementations with your team when you need deeper support."
-        className="relative overflow-hidden rounded-[2.5rem] border border-atsOcean/10 bg-gradient-to-br from-white to-atsSky/10 px-10 py-14"
+        className="relative overflow-hidden rounded-[2rem] border border-atsOcean/10 bg-gradient-to-br from-white to-atsSky/10 px-6 py-10 sm:rounded-[2.5rem] sm:px-10 sm:py-14"
       >
         {libraryInside.map((item) => (
           <Card
@@ -261,7 +261,7 @@ export default function Page() {
         title="Co-create with the Above The Stack community"
         description="Research and playbooks stay current because members stay involved. Bring your use case and shape the agenda."
         columns="three"
-        className="relative overflow-hidden rounded-[2.5rem] border border-atsOcean/10 bg-gradient-to-br from-white via-atsOcean/5 to-atsCoral/5 px-10 py-14"
+        className="relative overflow-hidden rounded-[2rem] border border-atsOcean/10 bg-gradient-to-br from-white via-atsOcean/5 to-atsCoral/5 px-6 py-10 sm:rounded-[2.5rem] sm:px-10 sm:py-14"
       >
         {collaboration.map((item) => (
           <Card

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import './globals.css'
 import Link from 'next/link'
 
@@ -26,6 +26,11 @@ export const metadata: Metadata = {
     siteName: 'Above The Stack',
   },
   twitter: { card: 'summary_large_image', title: 'Above The Stack' },
+}
+
+export const viewport: Viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -60,7 +65,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </div>
             </div>
             <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between lg:gap-12">
-              <nav className="-mx-2 flex items-center gap-2 overflow-x-auto pb-1 text-sm font-medium text-slate-600 lg:mx-0 lg:gap-8">
+              <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600 sm:-mx-2 sm:flex-nowrap sm:overflow-x-auto sm:pb-1 lg:mx-0 lg:gap-8">
                 {publicNavigation.map((item) => (
                   <Link
                     key={item.href}
@@ -87,7 +92,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </div>
         </header>
 
-        <main className="container pb-24 pt-16 lg:pt-24">{children}</main>
+        <main className="container pb-20 pt-14 sm:pt-16 lg:pt-24">{children}</main>
 
         <footer className="mt-24 border-t border-white/70 bg-white/80 py-16 backdrop-blur">
           <div className="container grid gap-12 lg:grid-cols-[2fr_1fr_1fr]">

--- a/app/newsletter/page.tsx
+++ b/app/newsletter/page.tsx
@@ -21,14 +21,14 @@ export default function Page() {
           currency equivalents available. Partners can request curated participation so
           conversations stay collaborative and sales-neutral.
         </p>
-        <div className="flex flex-wrap gap-3">
-          <a className="btn-primary" href={portalUrl}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <a className="btn-primary w-full justify-center sm:w-auto" href={portalUrl}>
             Log in to Above Connect
           </a>
-          <a className="btn-ghost" href={`${portalUrl}/signup`}>
+          <a className="btn-ghost w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
             Become a Member
           </a>
-          <a className="btn-ghost" href="mailto:partnerships@abovethestack.com">
+          <a className="btn-ghost w-full justify-center sm:w-auto" href="mailto:partnerships@abovethestack.com">
             Request an Invite
           </a>
         </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -271,11 +271,11 @@ export default function HomePage() {
               </span>
               Your MSP community is waiting inside Above Connect.
             </div>
-            <div className="flex flex-wrap gap-3">
-              <a className="btn-primary" href={`${portalUrl}/signup`}>
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+              <a className="btn-primary w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
                 Become a Member
               </a>
-              <a className="btn-secondary" href="mailto:partnerships@abovethestack.com">
+              <a className="btn-secondary w-full justify-center sm:w-auto" href="mailto:partnerships@abovethestack.com">
                 Talk to the team
               </a>
             </div>
@@ -310,7 +310,7 @@ export default function HomePage() {
         }
         columns="two"
         action={
-          <a className="btn-secondary" href={`${portalUrl}/signup`}>
+          <a className="btn-secondary w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
             Join the portal
           </a>
         }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -12,12 +12,12 @@ export default function Hero() {
   const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
   return (
-    <section className="relative overflow-hidden rounded-[2.75rem] border border-white/70 bg-white/80 px-8 py-16 shadow-[0_55px_110px_-60px_rgba(15,31,75,0.65)] backdrop-blur-xl md:px-16 md:py-24">
-      <div className="absolute -top-32 left-1/2 h-80 w-[32rem] -translate-x-1/2 rounded-full bg-gradient-to-r from-atsSky/35 via-white to-atsOcean/35 blur-3xl" />
-      <div className="absolute -bottom-40 right-0 h-96 w-[38rem] translate-x-1/4 rounded-full bg-gradient-to-br from-atsCoral/35 via-atsSky/20 to-transparent blur-3xl" />
+    <section className="relative overflow-hidden rounded-[2rem] border border-white/70 bg-white/80 px-6 py-14 shadow-[0_55px_110px_-60px_rgba(15,31,75,0.65)] backdrop-blur-xl sm:px-10 sm:py-16 lg:rounded-[2.75rem] lg:px-16 lg:py-24">
+      <div className="absolute -top-32 left-1/2 h-72 w-[22rem] -translate-x-1/2 rounded-full bg-gradient-to-r from-atsSky/35 via-white to-atsOcean/35 blur-3xl sm:h-80 sm:w-[32rem]" />
+      <div className="absolute -bottom-40 right-0 h-80 w-[26rem] translate-x-1/4 rounded-full bg-gradient-to-br from-atsCoral/35 via-atsSky/20 to-transparent blur-3xl sm:h-96 sm:w-[38rem]" />
       <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white via-atsSky/5 to-transparent opacity-60" />
 
-      <div className="relative grid items-start gap-12 lg:grid-cols-[1.4fr_1fr]">
+      <div className="relative grid items-start gap-10 lg:grid-cols-[1.4fr_1fr] lg:gap-12">
         <div className="space-y-10 text-left">
           <div className="space-y-5">
             <span className="inline-flex items-center gap-2 rounded-full border border-white/0 bg-atsOcean/10 px-4 py-1 text-sm font-semibold text-atsOcean/80 shadow-inner">
@@ -30,21 +30,21 @@ export default function Hero() {
               Independent research, living playbooks, and Above Connect — a trusted portal where MSPs, MSSPs, and partners work out the future of managed services together. Stay ahead of regulation, pricing, and customer expectations with peers who share openly.
             </p>
           </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <a className="btn-primary" href={`${portalUrl}/signup`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
+            <a className="btn-primary w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
               Join the Community
             </a>
-            <Link className="btn-secondary" href="/research">
+            <Link className="btn-secondary w-full justify-center sm:w-auto" href="/research">
               Explore Research
             </Link>
-            <span className="text-sm text-slate-500">
+            <span className="text-sm text-slate-500 sm:text-left">
               Already a member?{' '}
               <a className="font-semibold text-atsOcean hover:underline" href={portalUrl}>
                 Log in
               </a>
             </span>
           </div>
-          <dl className="grid gap-4 pt-4 sm:grid-cols-3">
+          <dl className="grid gap-3 pt-4 sm:grid-cols-3 sm:gap-4">
             {heroStats.map((stat) => (
               <div key={stat.label} className="rounded-2xl border border-white/80 bg-white/80 p-5 shadow-[0_18px_40px_-28px_rgba(15,31,75,0.45)]">
                 <dt className="text-sm font-semibold uppercase tracking-[0.35em] text-atsOcean/70">{stat.label}</dt>
@@ -54,7 +54,7 @@ export default function Hero() {
           </dl>
         </div>
 
-        <div className="card gradient-border space-y-6 bg-white/85 p-8">
+        <div className="card gradient-border space-y-6 bg-white/85 p-6 sm:p-8">
           <div className="flex items-start justify-between gap-3">
             <div>
               <h2 className="text-xl font-semibold text-atsMidnight">Community commitments</h2>
@@ -87,12 +87,12 @@ export default function Hero() {
               </div>
             ))}
           </div>
-          <div className="flex flex-wrap items-center gap-3 text-sm text-slate-600">
+          <div className="flex flex-col gap-2 text-sm text-slate-600 sm:flex-row sm:flex-wrap sm:items-center">
             <Link className="font-semibold text-atsOcean hover:underline" href="/community">
               Tour Above Connect
             </Link>
             <span className="hidden h-1 w-1 rounded-full bg-atsOcean/40 md:inline-block" aria-hidden />
-            <p>Membership is €150/year per company. Every teammate is included.</p>
+            <p className="sm:text-left">Membership is €150/year per company. Every teammate is included.</p>
           </div>
         </div>
       </div>

--- a/components/MemberCard.tsx
+++ b/components/MemberCard.tsx
@@ -12,7 +12,7 @@ export default function MemberCard({ member }: MemberCardProps) {
 
   return (
     <article className="card h-full overflow-hidden">
-      <div className="flex h-full flex-col gap-8 rounded-[2.25rem] bg-gradient-to-br from-atsOcean/5 via-white to-atsSky/5 px-8 py-9">
+      <div className="flex h-full flex-col gap-6 rounded-[2.25rem] bg-gradient-to-br from-atsOcean/5 via-white to-atsSky/5 px-6 py-7 sm:gap-8 sm:px-8 sm:py-9">
         <div className="flex flex-col gap-6 sm:flex-row sm:items-center">
           <div className="relative aspect-square w-24 shrink-0 rounded-[1.85rem] bg-gradient-to-br from-atsOcean/40 via-atsSky/25 to-atsCoral/30 p-[3px] shadow-[0_18px_32px_-18px_rgba(15,31,75,0.45)] sm:w-28">
             <div className="relative h-full w-full overflow-hidden rounded-[1.4rem] bg-white/85 shadow-[inset_0_1px_0_rgba(255,255,255,0.65)]">

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -19,23 +19,27 @@ export default function Section({
   children,
   className,
 }: SectionProps) {
-  const sectionClass = ['mt-28', className].filter(Boolean).join(' ')
+  const sectionClass = ['mt-20 md:mt-24 lg:mt-28', className].filter(Boolean).join(' ')
   const gridColumns =
     columns === 'one'
-      ? 'grid gap-8'
+      ? 'grid gap-6 sm:gap-8'
       : columns === 'two'
-        ? 'grid gap-8 md:grid-cols-2'
-        : 'grid gap-8 md:grid-cols-2 xl:grid-cols-3'
+        ? 'grid gap-6 sm:gap-8 md:grid-cols-2'
+        : 'grid gap-6 sm:gap-8 md:grid-cols-2 xl:grid-cols-3'
 
   return (
     <section className={sectionClass}>
-      <div className="mb-12 flex flex-col gap-6 md:flex-row md:items-end md:justify-between">
+      <div className="mb-10 flex flex-col gap-5 sm:mb-12 sm:gap-6 md:flex-row md:items-end md:justify-between">
         <div className="space-y-4">
           {eyebrow && <span className="eyebrow text-xs text-atsOcean/70">{eyebrow}</span>}
           <h2 className="h2 text-balance text-atsMidnight">{title}</h2>
           {description && <div className="muted max-w-3xl text-base leading-relaxed md:text-lg">{description}</div>}
         </div>
-        {action && <div className="flex flex-shrink-0 items-center gap-3">{action}</div>}
+        {action && (
+          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center md:flex-nowrap md:flex-shrink-0">
+            {action}
+          </div>
+        )}
       </div>
       <div className={gridColumns}>{children}</div>
     </section>


### PR DESCRIPTION
## Summary
- add viewport metadata and adjust global container/card spacing for smaller screens
- update shared hero and section components to stack actions and reduce spacing on phones
- tune hero sections across marketing pages so CTAs become full-width buttons on mobile

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0ac4cf5608327b48ae69e53fee1d2