### PR TITLE
Implement accessible mobile navigation drawer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from 'next'
 import './globals.css'
 import Link from 'next/link'
+import { MobileNavigation } from '@/components/mobile-navigation'
 
 const publicNavigation = [
   { href: '/insights', label: 'Insights' },
@@ -44,7 +45,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
         <header className="sticky top-0 z-50 border-b border-white/70 bg-white/85 backdrop-blur-xl">
           <div className="container flex flex-col gap-4 py-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex items-center justify-between gap-6">
+            <div className="flex w-full items-center justify-between gap-6">
               <Link
                 href="/"
                 className="flex items-center gap-3 text-lg font-semibold tracking-tight text-atsMidnight transition hover:text-atsOcean"
@@ -55,16 +56,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 <span className="hidden sm:inline">Above The Stack</span>
                 <span className="text-xs font-medium uppercase tracking-[0.3em] text-atsOcean/70 sm:hidden">ATS</span>
               </Link>
-              <div className="flex items-center gap-2 lg:hidden">
-                <Link className="btn-secondary px-4 py-2 text-xs" href={portalUrl}>
-                  Log in
-                </Link>
-                <Link className="btn-primary px-4 py-2 text-xs" href={`${portalUrl}/signup`}>
-                  Join
-                </Link>
-              </div>
+              <MobileNavigation items={publicNavigation} portalUrl={portalUrl} />
             </div>
-            <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between lg:gap-12">
+            <div className="hidden w-full lg:flex lg:items-center lg:justify-between lg:gap-12">
               <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600 sm:-mx-2 sm:flex-nowrap sm:overflow-x-auto sm:pb-1 lg:mx-0 lg:gap-8">
                 {publicNavigation.map((item) => (
                   <Link
@@ -76,7 +70,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   </Link>
                 ))}
               </nav>
-              <div className="hidden items-center gap-3 lg:flex">
+              <div className="flex items-center gap-3">
                 <div className="flex flex-col text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-atsOcean/60">
                   <span>Above Connect</span>
                 </div>

--- a/components/mobile-navigation.tsx
+++ b/components/mobile-navigation.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import Link from 'next/link'
+import { Menu, X } from 'lucide-react'
+import { useEffect, useId, useRef, useState } from 'react'
+
+const FOCUSABLE_SELECTORS = [
+  'a[href]',
+  'button:not([disabled])',
+  'textarea:not([disabled])',
+  'input:not([type="hidden"]):not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(', ')
+
+export type NavigationItem = {
+  href: string
+  label: string
+}
+
+type MobileNavigationProps = {
+  items: NavigationItem[]
+  portalUrl: string
+}
+
+export function MobileNavigation({ items, portalUrl }: MobileNavigationProps) {
+  const [isOpen, setIsOpen] = useState(false)
+  const drawerRef = useRef<HTMLDivElement | null>(null)
+  const toggleRef = useRef<HTMLButtonElement | null>(null)
+  const previouslyFocusedRef = useRef<HTMLElement | null>(null)
+  const reactId = useId().replace(/:/g, '')
+  const menuId = `mobile-navigation-${reactId}`
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    previouslyFocusedRef.current = document.activeElement as HTMLElement | null
+
+    const drawer = drawerRef.current
+
+    const focusableElements = () => {
+      if (!drawer) {
+        return [] as HTMLElement[]
+      }
+
+      return Array.from(drawer.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+        (element) => !element.hasAttribute('disabled') && element.getAttribute('aria-hidden') !== 'true',
+      )
+    }
+
+    const focusFirstElement = () => {
+      const [firstFocusable] = focusableElements()
+      firstFocusable?.focus()
+    }
+
+    focusFirstElement()
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        setIsOpen(false)
+        return
+      }
+
+      if (event.key !== 'Tab') {
+        return
+      }
+
+      const focusable = focusableElements()
+      if (focusable.length === 0) {
+        event.preventDefault()
+        return
+      }
+
+      const firstElement = focusable[0]
+      const lastElement = focusable[focusable.length - 1]
+      const active = document.activeElement as HTMLElement | null
+
+      if (event.shiftKey) {
+        if (active === firstElement || !drawer?.contains(active)) {
+          event.preventDefault()
+          lastElement.focus()
+        }
+        return
+      }
+
+      if (active === lastElement) {
+        event.preventDefault()
+        firstElement.focus()
+      }
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!drawer) {
+        return
+      }
+
+      if (!drawer.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    document.addEventListener('mousedown', handleClickOutside)
+
+    const originalOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown)
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.body.style.overflow = originalOverflow
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    if (isOpen) {
+      return
+    }
+
+    const previouslyFocused = previouslyFocusedRef.current ?? toggleRef.current
+    previouslyFocused?.focus()
+    previouslyFocusedRef.current = null
+  }, [isOpen])
+
+  return (
+    <div className="lg:hidden">
+      <button
+        ref={toggleRef}
+        type="button"
+        className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-atsMidnight shadow-sm transition hover:border-atsOcean/30 hover:text-atsOcean focus:outline-none focus:ring-2 focus:ring-atsOcean/50"
+        aria-expanded={isOpen}
+        aria-controls={menuId}
+        onClick={() => setIsOpen((previous) => !previous)}
+      >
+        <Menu aria-hidden="true" className="h-4 w-4" />
+        <span>Menu</span>
+      </button>
+
+      {isOpen ? (
+        <>
+          <div
+            className="fixed inset-0 z-40 bg-slate-900/30 backdrop-blur-sm"
+            aria-hidden="true"
+            onClick={() => setIsOpen(false)}
+          />
+          <div
+            ref={drawerRef}
+            id={menuId}
+            role="dialog"
+            aria-modal="true"
+            className="fixed inset-x-4 top-24 z-50 max-h-[80vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/95 p-6 shadow-2xl focus:outline-none"
+          >
+            <div className="flex items-center justify-between gap-4">
+              <div className="flex flex-col text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-atsOcean/60">
+                <span>Navigation</span>
+              </div>
+              <button
+                type="button"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-full border border-slate-200 text-slate-500 transition hover:border-atsOcean/30 hover:text-atsOcean focus:outline-none focus:ring-2 focus:ring-atsOcean/50"
+                onClick={() => setIsOpen(false)}
+                aria-label="Close menu"
+              >
+                <X aria-hidden="true" className="h-4 w-4" />
+              </button>
+            </div>
+
+            <nav className="mt-6 flex flex-col gap-2 text-base font-medium text-slate-700">
+              {items.map((item) => (
+                <Link
+                  key={item.href}
+                  className="rounded-full px-4 py-2 transition hover:bg-atsOcean/5 hover:text-atsOcean"
+                  href={item.href}
+                  onClick={() => setIsOpen(false)}
+                >
+                  {item.label}
+                </Link>
+              ))}
+            </nav>
+
+            <div className="mt-8 flex flex-col gap-3">
+              <Link className="btn-secondary w-full justify-center" href={portalUrl} onClick={() => setIsOpen(false)}>
+                Log in
+              </Link>
+              <Link
+                className="btn-primary w-full justify-center"
+                href={`${portalUrl}/signup`}
+                onClick={() => setIsOpen(false)}
+              >
+                Join
+              </Link>
+            </div>
+          </div>
+        </>
+      ) : null}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a client-side mobile navigation drawer with focus trapping, escape handling, and scroll locking
- replace the mobile header buttons with a toggleable menu that houses navigation and auth links
- integrate the drawer into the layout while keeping the desktop navigation intact

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0b7d057dc8327b6ccaa638594a183