### PR TITLE
feat: add animated hero background

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -22,6 +22,7 @@ body {
 
 .btn {
   @apply inline-flex items-center gap-2 rounded-full px-5 py-2.5 text-sm font-medium transition duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-atsOcean;
+  will-change: transform, box-shadow;
 }
 
 .btn-primary {
@@ -36,6 +37,28 @@ body {
 
 .btn-secondary {
   @apply btn border border-atsOcean/20 bg-white text-atsMidnight hover:border-atsOcean/40 hover:bg-atsOcean/5;
+}
+
+.btn-kinetic {
+  position: relative;
+  isolation: isolate;
+  transition-property: transform, box-shadow, background-position, opacity;
+}
+
+.btn-kinetic::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: radial-gradient(circle at 30% -20%, rgba(255, 255, 255, 0.55), transparent 65%);
+  opacity: 0;
+  transition: opacity 0.45s ease;
+  pointer-events: none;
+}
+
+.btn-kinetic:hover::after,
+.btn-kinetic:focus-visible::after {
+  opacity: 0.8;
 }
 
 .btn-ghost {
@@ -150,4 +173,94 @@ body {
   -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
   -webkit-mask-composite: xor;
   mask-composite: exclude;
+}
+
+.hero-glow {
+  position: absolute;
+  top: -35%;
+  left: 55%;
+  width: 32rem;
+  height: 32rem;
+  transform: translate3d(-50%, 0, 0);
+  border-radius: 9999px;
+  background:
+    radial-gradient(circle at 30% 35%, rgba(56, 156, 255, 0.55), transparent 60%),
+    radial-gradient(circle at 70% 65%, rgba(255, 122, 89, 0.38), transparent 65%);
+  filter: blur(70px);
+  opacity: 0.55;
+  pointer-events: none;
+  animation: heroGlowOrbit 28s ease-in-out infinite;
+}
+
+.hero-glow--secondary {
+  position: absolute;
+  top: auto;
+  bottom: -30%;
+  left: 15%;
+  width: 26rem;
+  height: 26rem;
+  background:
+    radial-gradient(circle at 40% 40%, rgba(56, 156, 255, 0.28), transparent 60%),
+    radial-gradient(circle at 70% 60%, rgba(38, 65, 214, 0.32), transparent 70%);
+  opacity: 0.4;
+  pointer-events: none;
+  animation: heroGlowDrift 32s ease-in-out infinite;
+}
+
+.hero-grid {
+  position: absolute;
+  inset: -30% -20% -35%;
+  background-image: radial-gradient(circle at center, rgba(15, 31, 75, 0.06) 0.5px, transparent 0.5px);
+  background-size: 32px 32px;
+  mix-blend-mode: soft-light;
+  transform: rotate(2deg);
+  animation: heroGridFloat 26s ease-in-out infinite;
+  pointer-events: none;
+  z-index: -10;
+}
+
+.hero-noise {
+  position: absolute;
+  inset: 0;
+  background-image: url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180"%3E%3Cfilter id="n" x="0" y="0" width="1" height="1"%3E%3CfeTurbulence type="fractalNoise" baseFrequency="0.7" numOctaves="4" stitchTiles="stitch"/%3E%3C/filter%3E%3Crect width="180" height="180" filter="url(%23n)" opacity="0.22"/%3E%3C/svg%3E');
+  opacity: 0.12;
+  mix-blend-mode: soft-light;
+  pointer-events: none;
+  z-index: -10;
+}
+
+@keyframes heroGlowOrbit {
+  0% {
+    transform: translate3d(-45%, 0, 0) scale(0.96) rotate(0deg);
+  }
+  50% {
+    transform: translate3d(-50%, 3%, 0) scale(1.05) rotate(12deg);
+  }
+  100% {
+    transform: translate3d(-45%, 0, 0) scale(0.96) rotate(0deg);
+  }
+}
+
+@keyframes heroGlowDrift {
+  0% {
+    transform: translate3d(-10%, 8%, 0) scale(0.9) rotate(-4deg);
+  }
+  50% {
+    transform: translate3d(4%, -4%, 0) scale(1.05) rotate(6deg);
+  }
+  100% {
+    transform: translate3d(-10%, 8%, 0) scale(0.9) rotate(-4deg);
+  }
+}
+
+@keyframes heroGridFloat {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(2deg) scale(1);
+  }
+  50% {
+    transform: translate3d(-1%, 1%, 0) rotate(1deg) scale(1.02);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) rotate(2deg) scale(1);
+  }
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,8 @@
+"use client"
+
 import Link from 'next/link'
 import { Sparkles } from 'lucide-react'
-import { motion } from 'framer-motion'
+import { motion, type Variants } from 'framer-motion'
 
 import { communityCommitments } from '@/data/community'
 import HeroBackground from './hero/HeroBackground'
@@ -13,7 +15,7 @@ const heroStats = [
 
 const MotionLink = motion(Link)
 
-const statVariants = {
+const statVariants: Variants = {
   hidden: { opacity: 0, y: 24 },
   visible: (index: number) => ({
     opacity: 1,
@@ -21,7 +23,7 @@ const statVariants = {
     transition: {
       delay: index * 0.08,
       duration: 0.6,
-      ease: 'easeOut',
+      ease: [0.16, 1, 0.3, 1],
     },
   }),
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link'
 import { Sparkles } from 'lucide-react'
+import { motion } from 'framer-motion'
+
 import { communityCommitments } from '@/data/community'
+import HeroBackground from './hero/HeroBackground'
 
 const heroStats = [
   { value: '18+', label: 'Countries represented' },
@@ -8,15 +11,26 @@ const heroStats = [
   { value: '6', label: 'Playbooks in motion' },
 ]
 
+const MotionLink = motion(Link)
+
+const statVariants = {
+  hidden: { opacity: 0, y: 24 },
+  visible: (index: number) => ({
+    opacity: 1,
+    y: 0,
+    transition: {
+      delay: index * 0.08,
+      duration: 0.6,
+      ease: 'easeOut',
+    },
+  }),
+}
+
 export default function Hero() {
   const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
 
   return (
-    <section className="relative overflow-hidden rounded-[2rem] border border-white/70 bg-white/80 px-6 py-14 shadow-[0_55px_110px_-60px_rgba(15,31,75,0.65)] backdrop-blur-xl sm:px-10 sm:py-16 lg:rounded-[2.75rem] lg:px-16 lg:py-24">
-      <div className="absolute -top-32 left-1/2 h-72 w-[22rem] -translate-x-1/2 rounded-full bg-gradient-to-r from-atsSky/35 via-white to-atsOcean/35 blur-3xl sm:h-80 sm:w-[32rem]" />
-      <div className="absolute -bottom-40 right-0 h-80 w-[26rem] translate-x-1/4 rounded-full bg-gradient-to-br from-atsCoral/35 via-atsSky/20 to-transparent blur-3xl sm:h-96 sm:w-[38rem]" />
-      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white via-atsSky/5 to-transparent opacity-60" />
-
+    <HeroBackground>
       <div className="relative grid items-start gap-10 lg:grid-cols-[1.4fr_1fr] lg:gap-12">
         <div className="space-y-10 text-left">
           <div className="space-y-5">
@@ -31,12 +45,24 @@ export default function Hero() {
             </p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-            <a className="btn-primary w-full justify-center sm:w-auto" href={`${portalUrl}/signup`}>
+            <motion.a
+              className="btn-primary btn-kinetic w-full justify-center sm:w-auto"
+              href={`${portalUrl}/signup`}
+              whileHover={{ y: -2, scale: 1.015 }}
+              whileFocus={{ y: -2, scale: 1.015 }}
+              whileTap={{ scale: 0.97 }}
+            >
               Join the Community
-            </a>
-            <Link className="btn-secondary w-full justify-center sm:w-auto" href="/research">
+            </motion.a>
+            <MotionLink
+              className="btn-secondary btn-kinetic w-full justify-center sm:w-auto"
+              href="/research"
+              whileHover={{ y: -2, scale: 1.01 }}
+              whileFocus={{ y: -2, scale: 1.01 }}
+              whileTap={{ scale: 0.97 }}
+            >
               Explore Research
-            </Link>
+            </MotionLink>
             <span className="text-sm text-slate-500 sm:text-left">
               Already a member?{' '}
               <a className="font-semibold text-atsOcean hover:underline" href={portalUrl}>
@@ -45,11 +71,19 @@ export default function Hero() {
             </span>
           </div>
           <dl className="grid gap-3 pt-4 sm:grid-cols-3 sm:gap-4">
-            {heroStats.map((stat) => (
-              <div key={stat.label} className="rounded-2xl border border-white/80 bg-white/80 p-5 shadow-[0_18px_40px_-28px_rgba(15,31,75,0.45)]">
+            {heroStats.map((stat, index) => (
+              <motion.div
+                key={stat.label}
+                className="rounded-2xl border border-white/80 bg-white/80 p-5 shadow-[0_18px_40px_-28px_rgba(15,31,75,0.45)]"
+                variants={statVariants}
+                initial="hidden"
+                whileInView="visible"
+                viewport={{ once: true, amount: 0.6 }}
+                custom={index}
+              >
                 <dt className="text-sm font-semibold uppercase tracking-[0.35em] text-atsOcean/70">{stat.label}</dt>
                 <dd className="mt-2 text-2xl font-semibold text-atsMidnight">{stat.value}</dd>
-              </div>
+              </motion.div>
             ))}
           </dl>
         </div>
@@ -96,6 +130,6 @@ export default function Hero() {
           </div>
         </div>
       </div>
-    </section>
+    </HeroBackground>
   )
 }

--- a/components/hero/HeroBackground.tsx
+++ b/components/hero/HeroBackground.tsx
@@ -1,5 +1,7 @@
+"use client"
+
 import { motion, useMotionTemplate, useMotionValue, useSpring, useTransform } from 'framer-motion'
-import { type PropsWithChildren, useCallback } from 'react'
+import { type PointerEvent, type PropsWithChildren, useCallback } from 'react'
 
 interface HeroBackgroundProps {
   className?: string
@@ -21,7 +23,7 @@ export default function HeroBackground({ children, className }: PropsWithChildre
   `
 
   const handlePointerMove = useCallback(
-    (event: React.PointerEvent<HTMLElement>) => {
+    (event: PointerEvent<HTMLElement>) => {
       const bounds = event.currentTarget.getBoundingClientRect()
       const x = ((event.clientX - bounds.left) / bounds.width) * 100
       const y = ((event.clientY - bounds.top) / bounds.height) * 100

--- a/components/hero/HeroBackground.tsx
+++ b/components/hero/HeroBackground.tsx
@@ -1,0 +1,60 @@
+import { motion, useMotionTemplate, useMotionValue, useSpring, useTransform } from 'framer-motion'
+import { type PropsWithChildren, useCallback } from 'react'
+
+interface HeroBackgroundProps {
+  className?: string
+}
+
+export default function HeroBackground({ children, className }: PropsWithChildren<HeroBackgroundProps>) {
+  const mouseX = useMotionValue(50)
+  const mouseY = useMotionValue(50)
+
+  const smoothX = useSpring(mouseX, { stiffness: 120, damping: 25, mass: 0.6 })
+  const smoothY = useSpring(mouseY, { stiffness: 120, damping: 25, mass: 0.6 })
+
+  const rotate = useTransform(smoothX, [0, 100], [-5, 5])
+
+  const gradient = useMotionTemplate`
+    radial-gradient(160% 160% at ${smoothX}% ${smoothY}%, rgba(56, 156, 255, 0.34), transparent 62%),
+    radial-gradient(120% 120% at calc(${smoothX}% + 18%) calc(${smoothY}% - 12%), rgba(255, 122, 89, 0.28), transparent 65%),
+    linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(241, 248, 255, 0.65) 45%, rgba(235, 244, 255, 0.92))
+  `
+
+  const handlePointerMove = useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      const bounds = event.currentTarget.getBoundingClientRect()
+      const x = ((event.clientX - bounds.left) / bounds.width) * 100
+      const y = ((event.clientY - bounds.top) / bounds.height) * 100
+
+      mouseX.set(Math.min(100, Math.max(0, x)))
+      mouseY.set(Math.min(100, Math.max(0, y)))
+    },
+    [mouseX, mouseY],
+  )
+
+  const handlePointerLeave = useCallback(() => {
+    mouseX.set(50)
+    mouseY.set(50)
+  }, [mouseX, mouseY])
+
+  const classes = ['relative overflow-hidden rounded-[2rem] border border-white/70 bg-white/80 px-6 py-14 shadow-[0_55px_110px_-60px_rgba(15,31,75,0.65)] backdrop-blur-xl sm:px-10 sm:py-16 lg:rounded-[2.75rem] lg:px-16 lg:py-24', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <motion.section
+      onPointerMove={handlePointerMove}
+      onPointerLeave={handlePointerLeave}
+      className={classes}
+      style={{ backgroundImage: gradient, rotate }}
+    >
+      <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white via-atsSky/10 to-transparent opacity-80" />
+      <div className="pointer-events-none hero-glow -z-10" aria-hidden />
+      <div className="pointer-events-none hero-glow hero-glow--secondary -z-10" aria-hidden />
+      <div className="pointer-events-none hero-grid" aria-hidden />
+      <div className="pointer-events-none hero-noise" aria-hidden />
+
+      <div className="relative z-10">{children}</div>
+    </motion.section>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "above-the-stack",
       "version": "0.1.0",
       "dependencies": {
+        "framer-motion": "^12.23.16",
         "lucide-react": "^0.544.0",
         "next": "14.2.11",
         "react": "18.3.1",
@@ -2814,6 +2815,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.23.16",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.16.tgz",
+      "integrity": "sha512-N81A8hiHqVsexOzI3wzkibyLURW1nEJsZaRuctPhG4AdbbciYu+bKJq9I2lQFzAO4Bx3h4swI6pBbF/Hu7f7BA==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.12",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3999,6 +4027,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.23.12",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
+      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.23.6"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.23.6",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
+      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "framer-motion": "^12.23.16",
     "lucide-react": "^0.544.0",
     "next": "14.2.11",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary
- install framer-motion and introduce a pointer-reactive hero background component with animated glow layers
- animate hero stats and calls-to-action using framer-motion for cohesive motion states
- extend global styles with glow, grid, and button utility classes to support the refreshed hero section

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0e2a97d0c83278954e2e5f3ce8aa5