### PR TITLE
Add parallax accents to sections

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -175,6 +175,170 @@ body {
   mask-composite: exclude;
 }
 
+.section-accent {
+  position: absolute;
+  inset: -14rem -30vw;
+  pointer-events: none;
+  z-index: -10;
+}
+
+.section-accent::before,
+.section-accent::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: clamp(48rem, 85vw, 74rem);
+  aspect-ratio: 16 / 9;
+  border-radius: 4rem;
+  transform: skewY(-6deg);
+  transition: opacity 0.6s ease;
+}
+
+.section-accent::before {
+  background: var(
+    --section-accent-gradient,
+    linear-gradient(135deg, rgba(38, 65, 214, 0.16), rgba(15, 31, 75, 0.08))
+  );
+  opacity: 0.85;
+}
+
+.section-accent::after {
+  inset: 6%;
+  background: var(
+    --section-accent-overlay,
+    radial-gradient(circle at 50% 45%, rgba(38, 65, 214, 0.28), transparent 70%)
+  );
+  opacity: 0.6;
+  mask-image: radial-gradient(circle at 50% 40%, rgba(0, 0, 0, 0.85), transparent 72%);
+  -webkit-mask-image: radial-gradient(circle at 50% 40%, rgba(0, 0, 0, 0.85), transparent 72%);
+}
+
+.section-accent__divider {
+  position: absolute;
+  bottom: clamp(-5rem, -8vw, -2rem);
+  left: 50%;
+  width: clamp(40rem, 90vw, 72rem);
+  transform: translateX(-50%);
+  color: var(--section-accent-stroke, rgba(38, 65, 214, 0.35));
+}
+
+.section-accent__divider path {
+  filter: drop-shadow(0 32px 68px rgba(15, 31, 75, 0.18));
+}
+
+.section-accent--ocean {
+  --section-accent-gradient: linear-gradient(135deg, rgba(38, 65, 214, 0.18), rgba(56, 156, 255, 0.12));
+  --section-accent-overlay:
+    radial-gradient(circle at 20% 25%, rgba(56, 156, 255, 0.32), transparent 65%),
+    radial-gradient(circle at 75% 45%, rgba(255, 122, 89, 0.18), transparent 68%);
+  --section-accent-stroke: rgba(38, 65, 214, 0.4);
+}
+
+.section-accent--sky {
+  --section-accent-gradient: linear-gradient(135deg, rgba(56, 156, 255, 0.18), rgba(171, 205, 255, 0.12));
+  --section-accent-overlay:
+    radial-gradient(circle at 18% 30%, rgba(146, 196, 255, 0.35), transparent 62%),
+    radial-gradient(circle at 80% 40%, rgba(56, 156, 255, 0.18), transparent 70%);
+  --section-accent-stroke: rgba(56, 156, 255, 0.38);
+}
+
+.section-accent--coral {
+  --section-accent-gradient: linear-gradient(135deg, rgba(255, 122, 89, 0.22), rgba(255, 196, 176, 0.16));
+  --section-accent-overlay:
+    radial-gradient(circle at 22% 30%, rgba(255, 160, 140, 0.32), transparent 60%),
+    radial-gradient(circle at 80% 45%, rgba(255, 191, 153, 0.24), transparent 72%);
+  --section-accent-stroke: rgba(255, 122, 89, 0.45);
+}
+
+.section-accent--midnight {
+  --section-accent-gradient: linear-gradient(135deg, rgba(15, 31, 75, 0.28), rgba(38, 65, 214, 0.2));
+  --section-accent-overlay:
+    radial-gradient(circle at 20% 25%, rgba(56, 156, 255, 0.18), transparent 65%),
+    radial-gradient(circle at 82% 50%, rgba(15, 31, 75, 0.35), transparent 70%);
+  --section-accent-stroke: rgba(15, 31, 75, 0.45);
+}
+
+.section-accent--slate {
+  --section-accent-gradient: linear-gradient(135deg, rgba(59, 83, 117, 0.22), rgba(15, 31, 75, 0.16));
+  --section-accent-overlay:
+    radial-gradient(circle at 25% 30%, rgba(119, 140, 170, 0.28), transparent 62%),
+    radial-gradient(circle at 78% 48%, rgba(59, 83, 117, 0.22), transparent 72%);
+  --section-accent-stroke: rgba(59, 83, 117, 0.38);
+}
+
+.section-connector {
+  position: absolute;
+  left: 50%;
+  width: 1px;
+  transform: translateX(-50%);
+  background: linear-gradient(
+    180deg,
+    transparent,
+    var(--section-connector-color, rgba(38, 65, 214, 0.2)) 55%,
+    transparent
+  );
+  pointer-events: none;
+  z-index: -20;
+  opacity: 0.95;
+}
+
+.section-connector::after {
+  content: '';
+  position: absolute;
+  left: 50%;
+  width: 140px;
+  height: 140px;
+  border-radius: 9999px;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(circle, var(--section-connector-glow, rgba(38, 65, 214, 0.22)), transparent 65%);
+  filter: blur(60px);
+  opacity: 0.85;
+}
+
+.section-connector--top {
+  top: -5.5rem;
+  height: 5rem;
+}
+
+.section-connector--top::after {
+  top: 0;
+}
+
+.section-connector--bottom {
+  bottom: -5.5rem;
+  height: 5rem;
+}
+
+.section-connector--bottom::after {
+  bottom: 0;
+}
+
+.section-connector--ocean {
+  --section-connector-color: rgba(38, 65, 214, 0.22);
+  --section-connector-glow: rgba(56, 156, 255, 0.22);
+}
+
+.section-connector--sky {
+  --section-connector-color: rgba(56, 156, 255, 0.24);
+  --section-connector-glow: rgba(171, 205, 255, 0.28);
+}
+
+.section-connector--coral {
+  --section-connector-color: rgba(255, 122, 89, 0.28);
+  --section-connector-glow: rgba(255, 160, 140, 0.32);
+}
+
+.section-connector--midnight {
+  --section-connector-color: rgba(15, 31, 75, 0.26);
+  --section-connector-glow: rgba(38, 65, 214, 0.22);
+}
+
+.section-connector--slate {
+  --section-connector-color: rgba(59, 83, 117, 0.26);
+  --section-connector-glow: rgba(119, 140, 170, 0.28);
+}
+
 .hero-glow {
   position: absolute;
   top: -35%;

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -216,6 +216,9 @@ export default function HomePage() {
         eyebrow="Fresh intelligence"
         title="What’s shipping to members next"
         description="Every release is shaped with community feedback before it goes live. Get a preview of the next drops the team is polishing."
+        accentColor="ocean"
+        showConnector
+        parallaxOffset={96}
       >
         <UpcomingHighlightsTimeline items={upcomingHighlights} autoplay showControls />
       </Section>
@@ -224,6 +227,9 @@ export default function HomePage() {
         eyebrow="By members, for members"
         title="The community runs on open contributions and peer accountability"
         description="Above The Stack is more than a portal — it’s a working studio for MSPs, MSSPs, and partners who believe in building together."
+        accentColor="coral"
+        showConnector
+        parallaxOffset={88}
       >
         {memberDesigned.map((feature) => (
           <Card
@@ -242,6 +248,9 @@ export default function HomePage() {
         title="One simple membership for your entire company"
         description="€150 per year per company. No per-seat math, no hidden tiers. Every teammate gets access to Above Connect and the resources the community is building."
         columns="two"
+        accentColor="sky"
+        showConnector
+        parallaxOffset={82}
       >
         <div className="card gradient-border space-y-6 bg-white/90">
           <div>
@@ -302,6 +311,7 @@ export default function HomePage() {
             Join the portal
           </a>
         }
+        accentColor="midnight"
       >
         <div className="card space-y-5">
           <h3 className="text-lg font-semibold text-atsMidnight">Inside the threads</h3>

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,4 +1,10 @@
+'use client'
+
 import type { ReactNode } from 'react'
+import { useEffect, useId, useRef, useState } from 'react'
+import { motion, useScroll, useTransform } from 'framer-motion'
+
+type AccentColor = 'ocean' | 'sky' | 'coral' | 'midnight' | 'slate'
 
 type SectionProps = {
   eyebrow?: string
@@ -8,6 +14,17 @@ type SectionProps = {
   columns?: 'one' | 'two' | 'three'
   children: ReactNode
   className?: string
+  accentColor?: AccentColor
+  showConnector?: boolean
+  parallaxOffset?: number
+}
+
+const accentClasses: Record<AccentColor, string> = {
+  ocean: 'section-accent--ocean',
+  sky: 'section-accent--sky',
+  coral: 'section-accent--coral',
+  midnight: 'section-accent--midnight',
+  slate: 'section-accent--slate',
 }
 
 export default function Section({
@@ -18,8 +35,33 @@ export default function Section({
   columns = 'three',
   children,
   className,
+  accentColor,
+  showConnector = false,
+  parallaxOffset = 72,
 }: SectionProps) {
-  const sectionClass = ['mt-20 md:mt-24 lg:mt-28', className].filter(Boolean).join(' ')
+  const sectionClass = ['relative isolate mt-20 md:mt-24 lg:mt-28', className]
+    .filter(Boolean)
+    .join(' ')
+
+  const sectionRef = useRef<HTMLElement | null>(null)
+  const { scrollYProgress } = useScroll({
+    target: sectionRef,
+    offset: ['start end', 'end start'],
+  })
+
+  const [hasMounted, setHasMounted] = useState(false)
+
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+
+  const parallaxDistance = Math.max(0, parallaxOffset)
+  const accentParallax = useTransform(scrollYProgress, [0, 1], [0, parallaxDistance])
+  const accentY = hasMounted ? accentParallax : 0
+
+  const rawGradientId = useId().replace(/:/g, '')
+  const gradientId = `section-divider-${rawGradientId}`
+
   const gridColumns =
     columns === 'one'
       ? 'grid gap-6 sm:gap-8'
@@ -27,21 +69,66 @@ export default function Section({
         ? 'grid gap-6 sm:gap-8 md:grid-cols-2'
         : 'grid gap-6 sm:gap-8 md:grid-cols-2 xl:grid-cols-3'
 
+  const connectorTone = accentColor ?? 'ocean'
+  const accentClassName = accentColor ? accentClasses[accentColor] : ''
+
   return (
-    <section className={sectionClass}>
-      <div className="mb-10 flex flex-col gap-5 sm:mb-12 sm:gap-6 md:flex-row md:items-end md:justify-between">
-        <div className="space-y-4">
-          {eyebrow && <span className="eyebrow text-xs text-atsOcean/70">{eyebrow}</span>}
-          <h2 className="h2 text-balance text-atsMidnight">{title}</h2>
-          {description && <div className="muted max-w-3xl text-base leading-relaxed md:text-lg">{description}</div>}
-        </div>
-        {action && (
-          <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center md:flex-nowrap md:flex-shrink-0">
-            {action}
+    <section ref={sectionRef} className={sectionClass}>
+      {accentColor && (
+        <motion.div
+          aria-hidden="true"
+          className={`section-accent ${accentClassName}`}
+          style={{ y: accentY }}
+        >
+          <svg className="section-accent__divider" viewBox="0 0 1440 320" preserveAspectRatio="none">
+            <defs>
+              <linearGradient id={gradientId} x1="0" y1="1" x2="1" y2="0">
+                <stop offset="0%" stopColor="currentColor" stopOpacity="0" />
+                <stop offset="50%" stopColor="currentColor" stopOpacity="0.45" />
+                <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
+              </linearGradient>
+            </defs>
+            <path
+              d="M0 200 C240 120 480 120 720 200 C960 280 1200 280 1440 200"
+              fill="none"
+              stroke={`url(#${gradientId})`}
+              strokeWidth="3"
+            />
+          </svg>
+        </motion.div>
+      )}
+
+      {showConnector && (
+        <span
+          aria-hidden="true"
+          className={`section-connector section-connector--top section-connector--${connectorTone}`}
+        />
+      )}
+
+      <div className="relative z-10">
+        <div className="mb-10 flex flex-col gap-5 sm:mb-12 sm:gap-6 md:flex-row md:items-end md:justify-between">
+          <div className="space-y-4">
+            {eyebrow && <span className="eyebrow text-xs text-atsOcean/70">{eyebrow}</span>}
+            <h2 className="h2 text-balance text-atsMidnight">{title}</h2>
+            {description && (
+              <div className="muted max-w-3xl text-base leading-relaxed md:text-lg">{description}</div>
+            )}
           </div>
-        )}
+          {action && (
+            <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center md:flex-nowrap md:flex-shrink-0">
+              {action}
+            </div>
+          )}
+        </div>
+        <div className={gridColumns}>{children}</div>
       </div>
-      <div className={gridColumns}>{children}</div>
+
+      {showConnector && (
+        <span
+          aria-hidden="true"
+          className={`section-connector section-connector--bottom section-connector--${connectorTone}`}
+        />
+      )}
     </section>
   )
 }


### PR DESCRIPTION
## Summary
- extend the reusable Section component with accent color, connector, and parallax options backed by framer-motion
- add diagonal accent utilities and connector line styles to the shared CSS to decorate highlighted sections
- opt key homepage sections into the new accents so the hero flow features intentional transitions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0fa12cc1483278d5f0ea1f69fc330