### PR TITLE
Fix timeline layout width

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -218,6 +218,7 @@ export default function HomePage() {
         description="Every release is shaped with community feedback before it goes live. Get a preview of the next drops the team is polishing."
         accentColor="ocean"
         showConnector
+        columns="one"
         parallaxOffset={96}
       >
         <UpcomingHighlightsTimeline items={upcomingHighlights} autoplay showControls />


### PR DESCRIPTION
## Summary
- configure the homepage timeline section to use the single-column layout so the carousel can span the available width

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0fc359e288327b04bc4ac33cce600