### PR TITLE
Improve section spacing and simplify highlights layout

### DIFF
--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -39,7 +39,13 @@ export default function Section({
   showConnector = false,
   parallaxOffset = 72,
 }: SectionProps) {
-  const sectionClass = ['relative isolate mt-20 md:mt-24 lg:mt-28', className]
+  const marginClasses = showConnector
+    ? 'mt-28 md:mt-32 lg:mt-36'
+    : 'mt-24 md:mt-28 lg:mt-32'
+
+  const paddingClasses = showConnector ? 'pt-12 md:pt-16 pb-12 md:pb-16' : ''
+
+  const sectionClass = ['relative isolate first:mt-0', marginClasses, paddingClasses, className]
     .filter(Boolean)
     .join(' ')
 

--- a/components/UpcomingHighlightsTimeline.tsx
+++ b/components/UpcomingHighlightsTimeline.tsx
@@ -36,12 +36,58 @@ function clamp(value: number, min: number, max: number) {
   return Math.min(Math.max(value, min), max)
 }
 
-export default function UpcomingHighlightsTimeline({
+type StaticTimelineProps = Pick<UpcomingHighlightsTimelineProps, 'items'>
+
+function StaticHighlightsTimeline({ items }: StaticTimelineProps) {
+  const itemCount = items.length
+  const gridColumns = itemCount === 1 ? '' : itemCount === 2 ? 'md:grid-cols-2' : 'md:grid-cols-3'
+  const gridClassName = ['grid gap-6 sm:gap-8', gridColumns].filter(Boolean).join(' ')
+
+  return (
+    <div className={gridClassName}>
+      {items.map((item, index) => {
+        const cardClassName = [item.className, 'shadow-glow'].filter(Boolean).join(' ')
+
+        return (
+          <motion.div
+            key={item.title}
+            className="h-full"
+            variants={MOTION_VARIANTS}
+            initial="hidden"
+            animate="visible"
+            transition={{ delay: index * 0.08, duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+          >
+            <Card
+              eyebrow={item.eyebrow}
+              title={item.title}
+              href={item.href}
+              cta={item.cta}
+              className={cardClassName}
+              icon={item.icon}
+              iconAccent={item.iconAccent}
+            >
+              {item.description}
+            </Card>
+          </motion.div>
+        )
+      })}
+    </div>
+  )
+}
+
+type CarouselTimelineProps = {
+  items: UpcomingHighlight[]
+  autoplay: boolean
+  autoplayInterval: number
+  showControls: boolean
+}
+
+function CarouselHighlightsTimeline({
   items,
-  autoplay = true,
-  autoplayInterval = 6500,
-  showControls = true,
-}: UpcomingHighlightsTimelineProps) {
+  autoplay,
+  autoplayInterval,
+  showControls,
+}: CarouselTimelineProps) {
   const slideCount = items.length
   const hasMultipleSlides = slideCount > 1
   const generatedId = useId()
@@ -307,5 +353,25 @@ export default function UpcomingHighlightsTimeline({
         Highlight {selectedIndex + 1} of {slideCount}
       </div>
     </div>
+  )
+}
+
+export default function UpcomingHighlightsTimeline({
+  items,
+  autoplay = true,
+  autoplayInterval = 6500,
+  showControls = true,
+}: UpcomingHighlightsTimelineProps) {
+  if (items.length <= 3) {
+    return <StaticHighlightsTimeline items={items} />
+  }
+
+  return (
+    <CarouselHighlightsTimeline
+      items={items}
+      autoplay={autoplay}
+      autoplayInterval={autoplayInterval}
+      showControls={showControls}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- add breathing room to Section instances, especially when connectors are rendered, to prevent sections from appearing stacked
- render the upcoming highlights as a simple responsive grid when only a handful of items exist while keeping the carousel for larger sets

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d100453fd483278905837d272d6763