### PR TITLE
Fix layout overflow and navbar scrolling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 
 html,
 body {
-  @apply min-h-screen bg-white text-slate-900 antialiased;
+  @apply min-h-screen bg-white text-slate-900 antialiased overflow-x-hidden;
   background-image:
     radial-gradient(circle at 20% -10%, rgba(51, 199, 255, 0.22), transparent 58%),
     radial-gradient(circle at 80% 0%, rgba(38, 65, 214, 0.18), transparent 60%),

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -59,7 +59,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <MobileNavigation items={publicNavigation} portalUrl={portalUrl} />
             </div>
             <div className="hidden w-full lg:flex lg:items-center lg:justify-between lg:gap-12">
-              <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600 sm:-mx-2 sm:flex-nowrap sm:overflow-x-auto sm:pb-1 lg:mx-0 lg:gap-8">
+              <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600 sm:-mx-2 sm:flex-nowrap lg:mx-0 lg:gap-8">
                 {publicNavigation.map((item) => (
                   <Link
                     key={item.href}


### PR DESCRIPTION
## Summary
- hide horizontal overflow on the document to keep the layout flush with the viewport edges
- stop applying horizontal scrolling styles to the desktop navigation bar so links stay static

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d1096b7e4c8327a2150b783a236309