### PR TITLE
Replace animation libs with native interactions

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,6 +4,21 @@
 
 :root {
   color-scheme: light;
+  --space-container-inline: clamp(1.25rem, 4vw, 3.25rem);
+  --space-page-top: clamp(4rem, 8vw, 6.5rem);
+  --space-page-bottom: clamp(4rem, 7vw, 6rem);
+  --space-section: clamp(3rem, 7vw, 5.5rem);
+  --space-section-connected: clamp(2.5rem, 6vw, 4.5rem);
+  --space-section-header: clamp(1.75rem, 3vw, 2.75rem);
+  --space-section-stack: clamp(1.25rem, 2.75vw, 1.85rem);
+  --space-card-gap: clamp(1.25rem, 3vw, 2rem);
+  --space-nav-block: clamp(0.75rem, 2vw, 1.25rem);
+  --space-nav-stack: clamp(0.75rem, 2.5vw, 1.4rem);
+  --space-nav-inline: clamp(1.1rem, 2.75vw, 1.75rem);
+  --space-nav-drawer-offset: clamp(5rem, 12vw, 7rem);
+  --space-footer-block: clamp(3rem, 7vw, 4.75rem);
+  --space-footer-stack: clamp(1.75rem, 4vw, 2.75rem);
+  --space-footer-meta: clamp(1.1rem, 3vw, 1.8rem);
 }
 
 html,
@@ -17,7 +32,10 @@ body {
 }
 
 .container {
-  @apply mx-auto max-w-7xl px-4 sm:px-6 md:px-10;
+  @apply mx-auto w-full;
+  max-width: 78rem;
+  padding-left: var(--space-container-inline);
+  padding-right: var(--space-container-inline);
 }
 
 .btn {
@@ -485,36 +503,22 @@ body {
 .timeline__container {
   display: flex;
   align-items: stretch;
-  gap: 1.25rem;
+  width: 100%;
+  gap: 0;
+  transition: transform 0.6s cubic-bezier(0.22, 1, 0.36, 1);
+  will-change: transform;
 }
 
 .timeline__slide {
-  flex: 0 0 82%;
+  flex: 0 0 100%;
   display: flex;
   min-width: 0;
-  padding-right: 0.25rem;
+  padding-inline: clamp(0.5rem, 4vw, 1rem);
+  box-sizing: border-box;
 }
 
 .timeline__slide > * {
   flex: 1 1 auto;
-}
-
-@media (min-width: 640px) {
-  .timeline__slide {
-    flex-basis: 60%;
-  }
-}
-
-@media (min-width: 1024px) {
-  .timeline__slide {
-    flex-basis: 45%;
-  }
-}
-
-@media (min-width: 1280px) {
-  .timeline__slide {
-    flex-basis: 33%;
-  }
 }
 
 .timeline__slide .card {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -39,13 +39,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
   return (
     <html lang="en">
-      <body className="relative min-h-screen bg-slate-50 text-slate-900">
+      <body className="relative flex min-h-screen flex-col bg-slate-50 text-slate-900">
         <div className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[520px] bg-gradient-to-b from-atsSky/15 via-transparent to-transparent" />
         <div className="pointer-events-none absolute inset-x-0 bottom-0 -z-10 h-[420px] bg-gradient-to-t from-atsOcean/5 via-transparent to-transparent" />
 
         <header className="sticky top-0 z-50 border-b border-white/70 bg-white/85 backdrop-blur-xl">
-          <div className="container flex flex-col gap-4 py-4 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex w-full items-center justify-between gap-6">
+          <div className="container flex flex-col gap-[var(--space-nav-stack)] py-[var(--space-nav-block)] lg:flex-row lg:items-center lg:justify-between">
+            <div className="flex w-full items-center justify-between gap-[var(--space-nav-inline)]">
               <Link
                 href="/"
                 className="flex items-center gap-3 text-lg font-semibold tracking-tight text-atsMidnight transition hover:text-atsOcean"
@@ -58,8 +58,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </Link>
               <MobileNavigation items={publicNavigation} portalUrl={portalUrl} />
             </div>
-            <div className="hidden w-full lg:flex lg:items-center lg:justify-between lg:gap-12">
-              <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600 sm:-mx-2 sm:flex-nowrap lg:mx-0 lg:gap-8">
+            <div className="hidden w-full lg:flex lg:items-center lg:justify-between lg:gap-[var(--space-nav-inline)]">
+              <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600 lg:flex-nowrap lg:gap-[var(--space-nav-inline)]">
                 {publicNavigation.map((item) => (
                   <Link
                     key={item.href}
@@ -70,7 +70,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                   </Link>
                 ))}
               </nav>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-[var(--space-nav-stack)]">
                 <div className="flex flex-col text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-atsOcean/60">
                   <span>Above Connect</span>
                 </div>
@@ -86,11 +86,13 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </div>
         </header>
 
-        <main className="container pb-20 pt-14 sm:pt-16 lg:pt-24">{children}</main>
+        <main className="container flex-1 space-y-[var(--space-section)] pb-[var(--space-page-bottom)] pt-[var(--space-page-top)]">
+          {children}
+        </main>
 
-        <footer className="mt-24 border-t border-white/70 bg-white/80 py-16 backdrop-blur">
-          <div className="container grid gap-12 lg:grid-cols-[2fr_1fr_1fr]">
-            <div className="space-y-6">
+        <footer className="mt-[var(--space-section)] border-t border-white/70 bg-white/80 py-[var(--space-footer-block)] backdrop-blur">
+          <div className="container grid gap-[var(--space-footer-stack)] lg:grid-cols-[2fr_1fr_1fr]">
+            <div className="space-y-[var(--space-section-stack)]">
               <Link href="/" className="text-xl font-semibold text-atsMidnight transition hover:text-atsOcean">
                 Above The Stack
               </Link>
@@ -114,7 +116,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </form>
               <p className="text-xs text-slate-500">Monthly digest. No noise — just highlights from the community.</p>
             </div>
-            <div className="space-y-4">
+            <div className="space-y-[var(--space-section-stack)]">
               <h3 className="text-sm font-semibold text-atsMidnight">Explore</h3>
               <div className="flex flex-col gap-2 text-sm text-slate-600">
                 {publicNavigation.map((item) => (
@@ -124,7 +126,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 ))}
               </div>
             </div>
-            <div className="space-y-4">
+            <div className="space-y-[var(--space-section-stack)]">
               <h3 className="text-sm font-semibold text-atsMidnight">Above Connect</h3>
               <div className="flex flex-col gap-2 text-sm text-slate-600">
                 <Link className="transition hover:text-atsOcean" href={`${portalUrl}/signup`}>
@@ -142,7 +144,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               </div>
             </div>
           </div>
-          <div className="container mt-12 flex flex-col gap-6 border-t border-white/70 pt-6 text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
+          <div className="container mt-[var(--space-footer-meta)] flex flex-col gap-[var(--space-footer-meta)] border-t border-white/70 pt-[var(--space-footer-meta)] text-xs text-slate-500 md:flex-row md:items-center md:justify-between">
             <p>© {new Date().getFullYear()} Above The Stack. Built together with the MSP community.</p>
             <div className="flex flex-wrap items-center gap-4">
               {socialLinks.map((item) => (

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -2,7 +2,6 @@
 
 import Link from 'next/link'
 import { Sparkles } from 'lucide-react'
-import { motion, type Variants } from 'framer-motion'
 
 import { communityCommitments } from '@/data/community'
 import HeroBackground from './hero/HeroBackground'
@@ -12,21 +11,6 @@ const heroStats = [
   { value: '40+', label: 'Member-led sessions' },
   { value: '6', label: 'Playbooks in motion' },
 ]
-
-const MotionLink = motion(Link)
-
-const statVariants: Variants = {
-  hidden: { opacity: 0, y: 24 },
-  visible: (index: number) => ({
-    opacity: 1,
-    y: 0,
-    transition: {
-      delay: index * 0.08,
-      duration: 0.6,
-      ease: [0.16, 1, 0.3, 1],
-    },
-  }),
-}
 
 export default function Hero() {
   const portalUrl = process.env.NEXT_PUBLIC_PORTAL_URL || 'https://portal.abovethestack.com'
@@ -47,24 +31,18 @@ export default function Hero() {
             </p>
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
-            <motion.a
-              className="btn-primary btn-kinetic w-full justify-center sm:w-auto"
+            <a
+              className="btn-primary btn-kinetic w-full justify-center transition-transform duration-200 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-atsOcean/40 sm:w-auto"
               href={`${portalUrl}/signup`}
-              whileHover={{ y: -2, scale: 1.015 }}
-              whileFocus={{ y: -2, scale: 1.015 }}
-              whileTap={{ scale: 0.97 }}
             >
               Join the Community
-            </motion.a>
-            <MotionLink
-              className="btn-secondary btn-kinetic w-full justify-center sm:w-auto"
+            </a>
+            <Link
+              className="btn-secondary btn-kinetic w-full justify-center transition-transform duration-200 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-atsOcean/40 sm:w-auto"
               href="/research"
-              whileHover={{ y: -2, scale: 1.01 }}
-              whileFocus={{ y: -2, scale: 1.01 }}
-              whileTap={{ scale: 0.97 }}
             >
               Explore Research
-            </MotionLink>
+            </Link>
             <span className="text-sm text-slate-500 sm:text-left">
               Already a member?{' '}
               <a className="font-semibold text-atsOcean hover:underline" href={portalUrl}>
@@ -73,19 +51,14 @@ export default function Hero() {
             </span>
           </div>
           <dl className="grid gap-3 pt-4 sm:grid-cols-3 sm:gap-4">
-            {heroStats.map((stat, index) => (
-              <motion.div
+            {heroStats.map((stat) => (
+              <div
                 key={stat.label}
-                className="rounded-2xl border border-white/80 bg-white/80 p-5 shadow-[0_18px_40px_-28px_rgba(15,31,75,0.45)]"
-                variants={statVariants}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: true, amount: 0.6 }}
-                custom={index}
+                className="rounded-2xl border border-white/80 bg-white/80 p-5 shadow-[0_18px_40px_-28px_rgba(15,31,75,0.45)] transition-transform duration-300 hover:-translate-y-1"
               >
                 <dt className="text-sm font-semibold uppercase tracking-[0.35em] text-atsOcean/70">{stat.label}</dt>
                 <dd className="mt-2 text-2xl font-semibold text-atsMidnight">{stat.value}</dd>
-              </motion.div>
+              </div>
             ))}
           </dl>
         </div>

--- a/components/hero/HeroBackground.tsx
+++ b/components/hero/HeroBackground.tsx
@@ -1,54 +1,70 @@
 "use client"
 
-import { motion, useMotionTemplate, useMotionValue, useSpring, useTransform } from 'framer-motion'
-import { type PointerEvent, type PropsWithChildren, useCallback } from 'react'
+import { type PointerEvent, type PropsWithChildren, useCallback, useMemo, useState } from 'react'
 
 interface HeroBackgroundProps {
   className?: string
 }
 
 export default function HeroBackground({ children, className }: PropsWithChildren<HeroBackgroundProps>) {
-  const mouseX = useMotionValue(50)
-  const mouseY = useMotionValue(50)
+  const [pointerPosition, setPointerPosition] = useState({ x: 50, y: 50 })
 
-  const smoothX = useSpring(mouseX, { stiffness: 120, damping: 25, mass: 0.6 })
-  const smoothY = useSpring(mouseY, { stiffness: 120, damping: 25, mass: 0.6 })
+  const handlePointerMove = useCallback((event: PointerEvent<HTMLElement>) => {
+    const bounds = event.currentTarget.getBoundingClientRect()
+    const relativeX = ((event.clientX - bounds.left) / bounds.width) * 100
+    const relativeY = ((event.clientY - bounds.top) / bounds.height) * 100
 
-  const rotate = useTransform(smoothX, [0, 100], [-5, 5])
+    const nextX = Math.min(100, Math.max(0, relativeX))
+    const nextY = Math.min(100, Math.max(0, relativeY))
 
-  const gradient = useMotionTemplate`
-    radial-gradient(160% 160% at ${smoothX}% ${smoothY}%, rgba(56, 156, 255, 0.34), transparent 62%),
-    radial-gradient(120% 120% at calc(${smoothX}% + 18%) calc(${smoothY}% - 12%), rgba(255, 122, 89, 0.28), transparent 65%),
-    linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(241, 248, 255, 0.65) 45%, rgba(235, 244, 255, 0.92))
-  `
+    setPointerPosition((previous) => {
+      if (Math.abs(previous.x - nextX) < 0.2 && Math.abs(previous.y - nextY) < 0.2) {
+        return previous
+      }
 
-  const handlePointerMove = useCallback(
-    (event: PointerEvent<HTMLElement>) => {
-      const bounds = event.currentTarget.getBoundingClientRect()
-      const x = ((event.clientX - bounds.left) / bounds.width) * 100
-      const y = ((event.clientY - bounds.top) / bounds.height) * 100
-
-      mouseX.set(Math.min(100, Math.max(0, x)))
-      mouseY.set(Math.min(100, Math.max(0, y)))
-    },
-    [mouseX, mouseY],
-  )
+      return { x: nextX, y: nextY }
+    })
+  }, [])
 
   const handlePointerLeave = useCallback(() => {
-    mouseX.set(50)
-    mouseY.set(50)
-  }, [mouseX, mouseY])
+    setPointerPosition((previous) => {
+      if (Math.abs(previous.x - 50) < 0.2 && Math.abs(previous.y - 50) < 0.2) {
+        return previous
+      }
+
+      return { x: 50, y: 50 }
+    })
+  }, [])
+
+  const gradient = useMemo(
+    () =>
+      `radial-gradient(160% 160% at ${pointerPosition.x}% ${pointerPosition.y}%, rgba(56, 156, 255, 0.34), transparent 62%),
+      radial-gradient(120% 120% at calc(${pointerPosition.x}% + 18%) calc(${pointerPosition.y}% - 12%), rgba(255, 122, 89, 0.28), transparent 65%),
+      linear-gradient(160deg, rgba(255, 255, 255, 0.92), rgba(241, 248, 255, 0.65) 45%, rgba(235, 244, 255, 0.92))`,
+    [pointerPosition.x, pointerPosition.y],
+  )
+
+  const rotation = useMemo(() => ((pointerPosition.x - 50) / 50) * 4.8, [pointerPosition.x])
+  const tilt = useMemo(() => ((50 - pointerPosition.y) / 50) * 3.2, [pointerPosition.y])
 
   const classes = ['relative overflow-hidden rounded-[2rem] border border-white/70 bg-white/80 px-6 py-14 shadow-[0_55px_110px_-60px_rgba(15,31,75,0.65)] backdrop-blur-xl sm:px-10 sm:py-16 lg:rounded-[2.75rem] lg:px-16 lg:py-24', className]
     .filter(Boolean)
-    .join(' ');
+    .join(' ')
+
+  const style = useMemo(
+    () => ({
+      backgroundImage: gradient,
+      transform: `perspective(1400px) rotateX(${tilt}deg) rotateY(${rotation / 1.6}deg)`,
+    }),
+    [gradient, rotation, tilt],
+  )
 
   return (
-    <motion.section
+    <section
       onPointerMove={handlePointerMove}
       onPointerLeave={handlePointerLeave}
-      className={classes}
-      style={{ backgroundImage: gradient, rotate }}
+      className={`${classes} transition-transform duration-700 ease-out`}
+      style={style}
     >
       <div className="pointer-events-none absolute inset-0 -z-10 bg-gradient-to-br from-white via-atsSky/10 to-transparent opacity-80" />
       <div className="pointer-events-none hero-glow -z-10" aria-hidden />
@@ -57,6 +73,6 @@ export default function HeroBackground({ children, className }: PropsWithChildre
       <div className="pointer-events-none hero-noise" aria-hidden />
 
       <div className="relative z-10">{children}</div>
-    </motion.section>
+    </section>
   )
 }

--- a/components/mobile-navigation.tsx
+++ b/components/mobile-navigation.tsx
@@ -151,7 +151,7 @@ export function MobileNavigation({ items, portalUrl }: MobileNavigationProps) {
             id={menuId}
             role="dialog"
             aria-modal="true"
-            className="fixed inset-x-4 top-24 z-50 max-h-[80vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/95 p-6 shadow-2xl focus:outline-none"
+            className="fixed inset-x-4 top-[var(--space-nav-drawer-offset)] z-50 max-h-[80vh] overflow-y-auto rounded-3xl border border-white/60 bg-white/95 p-6 shadow-2xl focus:outline-none"
           >
             <div className="flex items-center justify-between gap-4">
               <div className="flex flex-col text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-atsOcean/60">

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,6 @@
       "name": "above-the-stack",
       "version": "0.1.0",
       "dependencies": {
-        "embla-carousel-react": "^8.6.0",
-        "framer-motion": "^12.23.16",
         "lucide-react": "^0.544.0",
         "next": "14.2.11",
         "react": "18.3.1",
@@ -1988,34 +1986,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/embla-carousel": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
-      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
-    },
-    "node_modules/embla-carousel-react": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
-      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
-      "license": "MIT",
-      "dependencies": {
-        "embla-carousel": "8.6.0",
-        "embla-carousel-reactive-utils": "8.6.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/embla-carousel-reactive-utils": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
-      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "embla-carousel": "8.6.0"
-      }
-    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
@@ -2842,33 +2812,6 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
-      }
-    },
-    "node_modules/framer-motion": {
-      "version": "12.23.16",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.16.tgz",
-      "integrity": "sha512-N81A8hiHqVsexOzI3wzkibyLURW1nEJsZaRuctPhG4AdbbciYu+bKJq9I2lQFzAO4Bx3h4swI6pBbF/Hu7f7BA==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^12.23.12",
-        "motion-utils": "^12.23.6",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
       }
     },
     "node_modules/fs.realpath": {
@@ -4056,21 +3999,6 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/motion-dom": {
-      "version": "12.23.12",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
-      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^12.23.6"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "12.23.6",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
-      "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
-      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "embla-carousel-react": "^8.6.0",
-    "framer-motion": "^12.23.16",
     "lucide-react": "^0.544.0",
     "next": "14.2.11",
     "react": "18.3.1",


### PR DESCRIPTION
## Summary
- remove the framer-motion and Embla dependencies now that animations are handled in house
- rework the hero background, CTAs, and section accent to use lightweight React logic and CSS transitions instead of motion components
- rebuild the upcoming highlights timeline with a custom slider implementation and update the timeline styles to match

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d10bc7dc688327a6dacf06bd22f1bd