### PR TITLE
Improve focus styling for interactive cards

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -102,6 +102,16 @@ body {
   @apply -translate-y-1 shadow-glow;
 }
 
+.card:focus-visible,
+.card-focus {
+  @apply -translate-y-1 shadow-glow outline-none ring-2 ring-atsOcean/60 ring-offset-2 ring-offset-white;
+}
+
+.card:focus-visible::before,
+.card-focus::before {
+  opacity: 1;
+}
+
 .card:hover::before {
   opacity: 1;
 }

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -51,7 +51,10 @@ export default function Card({
 
   if (href) {
     return (
-      <Link href={href} className={`${baseClasses} block transform transition-transform duration-300 hover:-translate-y-1.5`}>
+      <Link
+        href={href}
+        className={`${baseClasses} block transform transition-transform duration-300 hover:-translate-y-1.5 focus-visible:card-focus focus-visible:outline-none`}
+      >
         {content}
       </Link>
     )

--- a/components/LatestThreads.tsx
+++ b/components/LatestThreads.tsx
@@ -56,7 +56,7 @@ export default function LatestThreads() {
           <a
             key={t.id}
             href={`${portal}/t/${t.slug}/${t.id}`}
-            className="card group flex h-full flex-col justify-between"
+            className="card group flex h-full flex-col justify-between focus-visible:card-focus focus-visible:outline-none"
           >
             <div className="space-y-2">
               <div className="text-sm font-semibold uppercase tracking-[0.2em] text-atsOcean/60">


### PR DESCRIPTION
## Summary
- add a focus-visible marker class to linked cards so CSS can detect keyboard focus
- update global card styles to mirror the hover elevation and add an accessible focus ring
- ensure ad-hoc card anchors inherit the new focus treatment

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d6642783a88327925f923d1597f629